### PR TITLE
feat: add global version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,11 @@ Zero dependencies. JSON output by default. Pipeable. Works with CapCut and JianY
 ```bash
 npm install -g capcut-cli
 ```
+Verify the installation:
 
+```bash
+capcut --version    # prints the installed CLI version
+```
 Or run directly:
 ```bash
 npx capcut-cli info ./my-project/

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ Usage: capcut <command> <project> [options]
 
 Global flags:
   -H, --human     Human-readable table output (default: JSON)
+  -v, --version   Print the installed CLI version
   -q, --quiet     No output on success, exit code only (write commands)
   --jianying      Use JianYing enum namespace (default: CapCut) for
                   transition, mask, text-anim, image-anim, add-effect, enums
@@ -453,6 +454,7 @@ interface Flags {
   // serve
   queue?: string;
   failFast?: boolean;
+  version?: boolean;
 }
 
 // Map CLI enum flags -> enums.json category key. Order matters for HELP text.
@@ -478,6 +480,7 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "-H" || a === "--human") flags.human = true;
+    else if (a === "-v" || a === "--version") flags.version = true;
     else if (a === "-q" || a === "--quiet") flags.quiet = true;
     else if (a === "--batch") flags.batch = true;
     else if ((a === "--track" || a === "--type") && i + 1 < args.length) {
@@ -1925,6 +1928,12 @@ function cmdDoctor(flags: Flags): boolean {
   return report.ok;
 }
 
+function getCliVersion(): string {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+  return pkg.version;
+}
+
 // --- Main ---
 
 async function main(): Promise<void> {
@@ -1935,6 +1944,11 @@ async function main(): Promise<void> {
   }
 
   const { positional, flags } = parseFlags(raw);
+
+  if (flags.version) {
+    console.log(getCliVersion());
+    process.exit(0);
+  }
   const cmd = positional[0];
   const projectPath = positional[1];
 

--- a/test/cli-version.test.mjs
+++ b/test/cli-version.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+
+describe("capcut --version", () => {
+  it("prints package version with --version", () => {
+    const r = spawnCli(["--version"]);
+
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout.trim(), pkg.version);
+  });
+
+  it("prints package version with -v", () => {
+    const r = spawnCli(["-v"]);
+
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout.trim(), pkg.version);
+  });
+});


### PR DESCRIPTION
## Summary

Add support for a global `--version` / `-v` flag that prints the installed CLI package version.

This keeps the existing `version` subcommand unchanged (`capcut version <project>` still reports CapCut/JianYing support information for a draft).

## Changes

* Add global `--version` and `-v` flags
* Read the package version from `package.json`
* Handle the flag before command dispatch
* Add tests covering both `--version` and `-v`
* Update the README installation section with a version-check example
* Update the CLI help output to document the new flag

## Example

```bash
capcut --version
0.6.0
```

## Testing

* Added CLI version flag tests
* `npm test` ✅
* Verified `capcut --version` and `capcut -v` print the installed version and exit successfully

Closes #10 