### PR TITLE
FEAT: Add 'templates' command to list bundled templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 
 ### Templates
 - ✅ [`save-template`](#templates) · [`apply-template`](#templates) — extract any segment as reusable JSON; restamp with new timing / position / text
-- ✅ [`template`](#templates) — List available templates that can be used
+- ✅ [`templates`](#templates) — List available templates that can be used
 - ✅ 6 templates ship in [`templates/`](./templates/): `gold-title`, `end-card`, `subscribe-cta`, `hook-question`, `lower-third`, `caption-pop`
 
 ### Import & discovery

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 
 ### Templates
 - ✅ [`save-template`](#templates) · [`apply-template`](#templates) — extract any segment as reusable JSON; restamp with new timing / position / text
-- ✅ [`template`](#templates) — List avaliable templates that can be used
+- ✅ [`template`](#templates) — List available templates that can be used
 - ✅ 6 templates ship in [`templates/`](./templates/): `gold-title`, `end-card`, `subscribe-cta`, `hook-question`, `lower-third`, `caption-pop`
 
 ### Import & discovery

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 
 ### Templates
 - ✅ [`save-template`](#templates) · [`apply-template`](#templates) — extract any segment as reusable JSON; restamp with new timing / position / text
-- ✅ 3 templates ship in [`templates/`](./templates/): `gold-title`, `end-card`, `subscribe-cta`
+- ✅ [`template`](#templates) — List avaliable templates that can be used
+- ✅ 6 templates ship in [`templates/`](./templates/): `gold-title`, `end-card`, `subscribe-cta`, `hook-question`, `lower-third`, `caption-pop`
 
 ### Import & discovery
 - ✅ [`import-srt`](#import-srt-subtitles-phase-3) — one cue per text segment; file, stdin, or `--style-ref` mirror

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseAss } from "./ass.js";
 import { captionDraft } from "./caption.js";
 import { removeChroma, setChroma } from "./chroma.js";
@@ -250,6 +252,9 @@ Templates:
   apply-template <project> <template.json> <start> <duration> [text override]
              Stamp a template into a project at the given time
              Options: --x <n> --y <n> (override position)
+  templates  
+             Show available templates in the template library.
+             Use -H for a table.
 
 Project:
   cut        <project> <start> <end> --out <path>
@@ -1925,6 +1930,48 @@ function cmdDoctor(flags: Flags): boolean {
   return report.ok;
 }
 
+function cmdTemplates(flags: Flags): void {
+  const cliDir = path.dirname(fileURLToPath(import.meta.url));
+  const templatesPath = path.join(cliDir, "..", "templates");
+
+  if (!existsSync(templatesPath)) {
+    die(`Templates directory not found: ${templatesPath}`);
+  }
+
+  const descriptions: Record<string, string> = {
+    "caption-pop": "word-highlight pop captions",
+    "lower-third": "name/title lower third",
+    "hook-question": "opening hook question card",
+    "gold-title": "gold title card",
+    "end-card": "end / outro card",
+    "subscribe-cta": "subscribe call-to-action",
+  };
+
+  const entries = readdirSync(templatesPath)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      const slug = path.basename(f, ".json");
+      return {
+        slug,
+        description: descriptions[slug] ?? slug.replace(/-/g, " "),
+      };
+    });
+
+  if (flags.human) {
+    if (entries.length === 0) {
+      console.log("No bundled templates found.");
+      return;
+    }
+    console.log(`${"Slug".padEnd(33)} Description`);
+    for (const e of entries) {
+      console.log(`${e.slug.padEnd(33)} ${e.description}`);
+    }
+    process.stderr.write(`\n${entries.length} templates\n`);
+  } else {
+    out(entries, flags);
+  }
+}
+
 // --- Main ---
 
 async function main(): Promise<void> {
@@ -1964,6 +2011,12 @@ async function main(): Promise<void> {
   // `export` iterates a directory of drafts — projectPath is the directory itself, not a single draft.
   if (cmd === "export") {
     cmdExport(positional, flags);
+    process.exit(0);
+  }
+
+  // `templates` list all available templates
+  if (cmd === "templates") {
+    cmdTemplates(flags);
     process.exit(0);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseAss } from "./ass.js";

--- a/test/showTemplates.test.mjs
+++ b/test/showTemplates.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+describe("capcut available templates", () => {
+  it("lists available templates as JSON by default", () => {
+    const r = spawnCli(["templates"]);
+
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(r.json, "stdout should be valid JSON");
+    assert.ok(Array.isArray(r.json));
+
+    const slugs = r.json.map((t) => t.slug);
+
+    assert.ok(slugs.includes("caption-pop"));
+    assert.ok(slugs.includes("lower-third"));
+    assert.ok(slugs.includes("hook-question"));
+    assert.ok(slugs.includes("gold-title"));
+    assert.ok(slugs.includes("end-card"));
+    assert.ok(slugs.includes("subscribe-cta"));
+  });
+
+  it("renders a human-readable layout with -H", () => {
+    const r = spawnCli(["templates", "-H"]);
+
+    assert.equal(r.status, 0);
+
+    assert.match(r.stdout, /Slug/);
+    assert.match(r.stdout, /caption-pop/);
+    assert.match(r.stdout, /gold-title/);
+  });
+});


### PR DESCRIPTION
### Summary
Adds a new `templates` command to make bundled templates discoverable from the CLI.

Previously, users could apply bundled templates via apply-template, but there was no way to list the available templates without inspecting the repository contents. This change introduces a dedicated command that enumerates bundled templates from the shipped templates/ directory.

## Usage

`capcut templates`  or `capcut templates -H`


## Resolves
Resolves #11 

### Changes

- Added capcut templates command.
- Resolves bundled templates from the package templates/ directory.
- Supports human-readable output with -H / --human.
- Added descriptions for bundled templates:
```
- caption-pop
- lower-third
- hook-question
- gold-title
- end-card
- subscribe-cta
```
- Added automated tests covering


## Screenshots
### `capcut templates` or `capcut templates -H`

<img width="1387" height="511" alt="Screenshot 2026-05-30 215106" src="https://github.com/user-attachments/assets/3d80082b-7e83-40e3-9ef3-b27357764bab" />

### `npm run test`

<img width="1380" height="333" alt="Screenshot 2026-05-30 215134" src="https://github.com/user-attachments/assets/31e81bcf-9928-42d9-a88d-be92134a3733" />


### `capcut --help`
<img width="1418" height="294" alt="Screenshot 2026-05-30 215214" src="https://github.com/user-attachments/assets/7612c38d-cf5c-4b71-8eaa-fc0ffc2c1969" />




Please review the PR at your convenience and suggest improvements required. I will try my best to resolve it. 

Thanks a lot!
