### PR TITLE
chore: pin Biome to 2.4.15 and clear auto-fixable lint debt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "capcut-cli",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capcut-cli",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "license": "MIT",
       "bin": {
         "capcut": "dist/index.js",
         "capcut-cli": "dist/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.15",
+        "@biomejs/biome": "2.4.15",
         "@types/node": "^25.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "2.4.15",
     "@types/node": "^25.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.4",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -28,43 +28,43 @@ export function parseKeyframeValue(property: string, value: string): number {
   const v = value.trim();
   if (property === "position_x" || property === "position_y") {
     const n = parseFloat(v);
-    if (!isFinite(n) || n < -10 || n > 10)
+    if (!Number.isFinite(n) || n < -10 || n > 10)
       throw new Error(`${property} must be a finite number in [-10, 10], got: ${value}`);
     return n;
   }
   if (property === "rotation") {
     const raw = v.endsWith("deg") ? v.slice(0, -3) : v;
     const n = parseFloat(raw);
-    if (!isFinite(n)) throw new Error(`Invalid rotation value: ${value}`);
+    if (!Number.isFinite(n)) throw new Error(`Invalid rotation value: ${value}`);
     return n;
   }
   if (property === "alpha" || property === "volume") {
     if (v.endsWith("%")) {
       const n = parseFloat(v.slice(0, -1));
-      if (!isFinite(n)) throw new Error(`Invalid ${property} percentage: ${value}`);
+      if (!Number.isFinite(n)) throw new Error(`Invalid ${property} percentage: ${value}`);
       return n / 100;
     }
     const n = parseFloat(v);
-    if (!isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
+    if (!Number.isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
     return n;
   }
   if (property === "saturation" || property === "contrast" || property === "brightness") {
     if (v.startsWith("+")) {
       const n = parseFloat(v.slice(1));
-      if (!isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
+      if (!Number.isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
       return n;
     }
     if (v.startsWith("-")) {
       const n = parseFloat(v.slice(1));
-      if (!isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
+      if (!Number.isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
       return -n;
     }
     const n = parseFloat(v);
-    if (!isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
+    if (!Number.isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
     return n;
   }
   const n = parseFloat(v);
-  if (!isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
+  if (!Number.isFinite(n)) throw new Error(`Invalid ${property} value: ${value}`);
   return n;
 }
 
@@ -154,7 +154,7 @@ export function addTransition(
   namespace: Namespace = "capcut",
 ): { segmentId: string; transition_id: string; name: string; duration_us: number } {
   const meta = findEnum("transitions", slug, namespace);
-  if (!meta || !meta.name || !meta.effect_id || !meta.resource_id) {
+  if (!meta?.name || !meta.effect_id || !meta.resource_id) {
     const hint = namespace === "jianying" ? " --jianying" : "";
     throw new Error(`Unknown transition: ${slug}. Run 'capcut enums --transitions${hint}' for the full list.`);
   }
@@ -218,7 +218,7 @@ export function addMask(
   namespace: Namespace = "capcut",
 ): { segmentId: string; mask_id: string; name: string } {
   const meta = findEnum("masks", slug, namespace, MASK_ALIASES);
-  if (!meta || !meta.name || !meta.effect_id || !meta.resource_id || !meta.resource_type) {
+  if (!meta?.name || !meta.effect_id || !meta.resource_id || !meta.resource_type) {
     const hint = namespace === "jianying" ? " --jianying" : "";
     throw new Error(`Unknown mask: ${slug}. Run 'capcut enums --masks${hint}' for the full list.`);
   }
@@ -630,7 +630,7 @@ export function addImageAnim(
     } else {
       const category = animType === "in" ? "image_intros" : animType === "out" ? "image_outros" : "image_combos";
       const meta = findEnum(category, slug, namespace);
-      if (!meta || !meta.effect_id || !meta.resource_id) {
+      if (!meta?.effect_id || !meta.resource_id) {
         const hint = namespace === "jianying" ? " --jianying" : "";
         throw new Error(
           `Unknown image ${animType} animation: ${slug}. Run 'capcut enums --image-${animType === "in" ? "intros" : animType === "out" ? "outros" : "combos"}${hint}' for the full list.`,
@@ -728,7 +728,7 @@ export function addTextAnim(
   const addOne = (slug: string, overrideDur: number | undefined, animType: "in" | "out") => {
     const category = animType === "in" ? "text_intros" : "text_outros";
     const meta = findEnum(category, slug, namespace, TEXT_ANIM_ALIASES);
-    if (!meta || !meta.effect_id || !meta.resource_id) {
+    if (!meta?.effect_id || !meta.resource_id) {
       const hint = namespace === "jianying" ? " --jianying" : "";
       throw new Error(
         `Unknown text ${animType === "in" ? "intro" : "outro"}: ${slug}. Run 'capcut enums --text-${animType === "in" ? "intros" : "outros"}${hint}' for the full list.`,
@@ -813,7 +813,7 @@ export function setTextRanges(
   const byteLen = Buffer.from(full, "utf16le").length;
 
   // Baseline style inherited for fields the user didn't override.
-  const base = (content.styles && content.styles[0]) ?? {};
+  const base = content.styles?.[0] ?? {};
   const baseFill = (
     base.fill as { content?: { solid?: { color?: [number, number, number]; alpha?: number } } } | undefined
   )?.content?.solid;

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -112,7 +112,7 @@ export function loadDraft(path: string): { draft: Draft; filePath: string } {
 }
 
 export function saveDraft(filePath: string, draft: Draft): void {
-  const bakPath = filePath + ".bak";
+  const bakPath = `${filePath}.bak`;
   if (existsSync(filePath)) {
     const original = rawOriginal ?? readFileSync(filePath, "utf-8");
     writeFileSync(bakPath, original, "utf-8");

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -314,7 +314,7 @@ export function copyTextStyle(draft: Draft, refSegmentId: string, targetMaterial
 
 export function addText(
   draft: Draft,
-  filePath: string,
+  _filePath: string,
   opts: AddTextOptions,
 ): { segmentId: string; materialId: string; trackId: string } {
   const segId = uuid();
@@ -996,7 +996,7 @@ export function addEffect(
     const scene = findEnum("scene_effects", opts.slug, ns);
     const char = scene ? null : findEnum("character_effects", opts.slug, ns);
     const hit = scene ?? char;
-    if (!hit || !hit.name || !hit.effect_id || !hit.resource_id) {
+    if (!hit?.name || !hit.effect_id || !hit.resource_id) {
       const hint = ns === "jianying" ? " --jianying" : "";
       throw new Error(
         `Unknown effect slug: ${opts.slug}. Run 'capcut enums --scene-effects${hint}' or '--character-effects${hint}' for the full list.`,
@@ -1266,7 +1266,7 @@ export function addFilter(
   let meta: FilterMeta | null = ns === "capcut" ? (VIDEO_FILTERS[opts.slug.toLowerCase()] ?? null) : null;
   if (!meta) {
     const hit = findEnum("filters", opts.slug, ns);
-    if (!hit || !hit.name || !hit.effect_id || !hit.resource_id) {
+    if (!hit?.name || !hit.effect_id || !hit.resource_id) {
       const hint = ns === "jianying" ? " --jianying" : "";
       throw new Error(`Unknown filter slug: ${opts.slug}. Run 'capcut enums --filters${hint}' for the full list.`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ import {
   setTextRanges,
   setTextStyle,
   textAnimSlugs,
-  transitionSlugs,
 } from "./decorators.js";
 import { detectEncryption } from "./decrypt.js";
 import { type DoctorCheck, runDoctor } from "./doctor.js";
@@ -47,7 +46,7 @@ import {
 } from "./draft.js";
 import { type Category, listEnum, type Namespace } from "./enums.js";
 import { exportBatch } from "./export-batch.js";
-import type { AddAudioOptions, AddTextOptions, AddVideoOptions, CutOptions, InitOptions } from "./factory.js";
+import type { AddAudioOptions, AddTextOptions, AddVideoOptions, CutOptions } from "./factory.js";
 import {
   addAudio,
   addEffect,
@@ -489,7 +488,7 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
     } else if (a === "--color" && i + 1 < args.length) {
       flags.color = args[++i];
     } else if (a === "--align" && i + 1 < args.length) {
-      flags.align = parseInt(args[++i]);
+      flags.align = parseInt(args[++i], 10);
     } else if (a === "--x" && i + 1 < args.length) {
       flags.x = parseFloat(args[++i]);
     } else if (a === "--y" && i + 1 < args.length) {
@@ -555,7 +554,7 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
     } else if (a === "--bg-alpha" && i + 1 < args.length) {
       flags.bgAlpha = parseFloat(args[++i]);
     } else if (a === "--bg-style" && i + 1 < args.length) {
-      flags.bgStyle = parseInt(args[++i]);
+      flags.bgStyle = parseInt(args[++i], 10);
     } else if (a === "--bg-round-radius" && i + 1 < args.length) {
       flags.bgRoundRadius = parseFloat(args[++i]);
     } else if (a === "--bg-width" && i + 1 < args.length) {
@@ -609,7 +608,7 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
     } else if (a === "--force-license") {
       flags.forceLicense = true;
     } else if (a === "--max-chars" && i + 1 < args.length) {
-      flags.maxChars = parseInt(args[++i]);
+      flags.maxChars = parseInt(args[++i], 10);
     } else if (a === "--max-cue-secs" && i + 1 < args.length) {
       flags.maxCueSecs = parseFloat(args[++i]);
     } else if (a === "--min-gap-ms" && i + 1 < args.length) {
@@ -658,7 +657,7 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
 
 function out(data: unknown, flags: Flags): void {
   if (flags.quiet) return;
-  process.stdout.write(JSON.stringify(data) + "\n");
+  process.stdout.write(`${JSON.stringify(data)}\n`);
 }
 
 class CliError extends Error {
@@ -743,7 +742,7 @@ function cmdTracks(draft: Draft, flags: Flags): void {
       if (t.hidden) fl.push("hidden");
       if (t.locked) fl.push("locked");
       console.log(
-        `${String(t.index).padStart(2)}  ${t.type.padEnd(8)} ${t.name.padEnd(14)} ${String(t.segments).padStart(4)} segs  ${formatDuration(t.duration_us).padStart(10)}${fl.length ? "  [" + fl.join(",") + "]" : ""}`,
+        `${String(t.index).padStart(2)}  ${t.type.padEnd(8)} ${t.name.padEnd(14)} ${String(t.segments).padStart(4)} segs  ${formatDuration(t.duration_us).padStart(10)}${fl.length ? `  [${fl.join(",")}]` : ""}`,
       );
     }
   } else {
@@ -785,7 +784,7 @@ function cmdSegments(draft: Draft, flags: Flags): void {
     for (const s of data) {
       const end = s.start_us + s.duration_us;
       console.log(
-        `${s.id.slice(0, 8)}  ${s.type.padEnd(6)} ${formatTime(s.start_us).padStart(8)}-${formatTime(end).padStart(8)}  ${formatDuration(s.duration_us).padStart(8)}  ${s.speed !== 1 ? s.speed + "x" : "   "}  ${s.label.slice(0, 40)}`,
+        `${s.id.slice(0, 8)}  ${s.type.padEnd(6)} ${formatTime(s.start_us).padStart(8)}-${formatTime(end).padStart(8)}  ${formatDuration(s.duration_us).padStart(8)}  ${s.speed !== 1 ? `${s.speed}x` : "   "}  ${s.label.slice(0, 40)}`,
       );
     }
   } else {
@@ -863,7 +862,7 @@ function cmdSpeed(draft: Draft, filePath: string, segId: string, multiplier: str
   const result = findSegment(draft, segId);
   if (!result) die(`Segment not found: ${segId}`);
   const speed = parseFloat(multiplier);
-  if (isNaN(speed) || speed <= 0) die("Speed must be a positive number");
+  if (Number.isNaN(speed) || speed <= 0) die("Speed must be a positive number");
   const seg = result.segment;
   const oldSpeed = seg.speed;
   seg.speed = speed;
@@ -880,7 +879,7 @@ function cmdVolume(draft: Draft, filePath: string, segId: string, levelStr: stri
   const result = findSegment(draft, segId);
   if (!result) die(`Segment not found: ${segId}`);
   const level = parseFloat(levelStr);
-  if (isNaN(level) || level < 0) die("Volume must be >= 0");
+  if (Number.isNaN(level) || level < 0) die("Volume must be >= 0");
   const old = result.segment.volume;
   result.segment.volume = level;
   if (save) saveDraft(filePath, draft);
@@ -921,7 +920,7 @@ function cmdOpacity(draft: Draft, filePath: string, segId: string, alphaStr: str
   const result = findSegment(draft, segId);
   if (!result) die(`Segment not found: ${segId}`);
   const alpha = parseFloat(alphaStr);
-  if (isNaN(alpha) || alpha < 0 || alpha > 1) die("Opacity must be 0.0-1.0");
+  if (Number.isNaN(alpha) || alpha < 0 || alpha > 1) die("Opacity must be 0.0-1.0");
   if (!result.segment.clip) die(`Segment ${segId} has no clip (audio segment?)`);
   const old = result.segment.clip.alpha;
   result.segment.clip.alpha = alpha;
@@ -1032,7 +1031,7 @@ async function cmdAddAudio(draft: Draft, filePath: string, positional: string[],
     die("Usage: capcut add-audio <project> <file-or-wikimedia-url> <start> <duration>");
   // Wikimedia URLs go through the license-gated fetcher; locals pass through.
   const { localPath, asset, warning } = await resolveAssetPath(audioPath, filePath, "audio", flags.forceLicense);
-  const absPath = localPath.startsWith("/") ? localPath : process.cwd() + "/" + localPath;
+  const absPath = localPath.startsWith("/") ? localPath : `${process.cwd()}/${localPath}`;
   const start = parseTimeInput(startStr);
   const duration = parseTimeInput(durationStr);
   const opts: AddAudioOptions = {
@@ -1074,7 +1073,7 @@ async function cmdAddVideo(draft: Draft, filePath: string, positional: string[],
   if (!videoPath || !startStr || !durationStr)
     die("Usage: capcut add-video <project> <file-or-wikimedia-url> <start> <duration>");
   const { localPath, asset, warning } = await resolveAssetPath(videoPath, filePath, "video", flags.forceLicense);
-  const absPath = localPath.startsWith("/") ? localPath : process.cwd() + "/" + localPath;
+  const absPath = localPath.startsWith("/") ? localPath : `${process.cwd()}/${localPath}`;
   const start = parseTimeInput(startStr);
   const duration = parseTimeInput(durationStr);
   const opts: AddVideoOptions = {
@@ -1239,7 +1238,7 @@ function cmdBgBlur(draft: Draft, filePath: string, positional: string[], flags: 
   let level: 1 | 2 | 3 | 4 | "off";
   if (flags.off) level = "off";
   else {
-    const n = parseInt(arg ?? "");
+    const n = parseInt(arg ?? "", 10);
     if (![1, 2, 3, 4].includes(n)) die(`bg-blur level must be 1, 2, 3, or 4 (or --off)`);
     level = n as 1 | 2 | 3 | 4;
   }
@@ -1436,7 +1435,7 @@ function cmdMixMode(draft: Draft, filePath: string, positional: string[], flags:
   out({ ok: true, ...result }, flags);
 }
 
-function cmdCut(draft: Draft, filePath: string, positional: string[], flags: Flags): void {
+function cmdCut(draft: Draft, _filePath: string, positional: string[], flags: Flags): void {
   if (!flags.out) die("Missing --out <path>. Usage: capcut cut <project> <start> <end> --out <path>");
   const start = parseTimeInput(positional[2]);
   const end = parseTimeInput(positional[3]);
@@ -1829,7 +1828,7 @@ async function cmdServe(flags: Flags): Promise<void> {
     failFast: flags.failFast,
   });
   // Write a final summary line at end (JSON only, stderr to avoid mixing with per-job results)
-  process.stderr.write(JSON.stringify({ summary: result }) + "\n");
+  process.stderr.write(`${JSON.stringify({ summary: result })}\n`);
 }
 
 // --- Batch ---
@@ -1899,7 +1898,7 @@ function cmdBatch(draft: Draft, filePath: string, flags: Flags): void {
     } catch (e) {
       fail++;
       const msg = e instanceof Error ? e.message : String(e);
-      process.stderr.write(JSON.stringify({ error: msg, line: trimmed }) + "\n");
+      process.stderr.write(`${JSON.stringify({ error: msg, line: trimmed })}\n`);
     }
   }
   saveDraft(filePath, draft);
@@ -1973,14 +1972,13 @@ async function main(): Promise<void> {
     if (!name) die("Missing name. Usage: capcut init <name> [--template <dir>] [--drafts <dir>]");
     const cliDir = new URL(".", import.meta.url).pathname.replace(/\/dist\/$/, "");
     // Default template resolution: user --template > ../CapCutAPI/template > bundled _init template
-    const externalTemplate = cliDir + "/../CapCutAPI/template";
-    const bundledTemplate = cliDir + "/templates/_init";
+    const externalTemplate = `${cliDir}/../CapCutAPI/template`;
+    const bundledTemplate = `${cliDir}/templates/_init`;
     let templateDir = flags.template ?? externalTemplate;
     if (!flags.template && !existsSync(templateDir) && existsSync(bundledTemplate)) {
       templateDir = bundledTemplate;
     }
-    const draftsDir =
-      flags.drafts ?? (process.env.HOME || "~") + "/Movies/CapCut/User Data/Projects/com.lveditor.draft";
+    const draftsDir = flags.drafts ?? `${process.env.HOME || "~"}/Movies/CapCut/User Data/Projects/com.lveditor.draft`;
     const result = initDraft({ name, templateDir, draftsDir });
     out({ ok: true, name, draft_path: result.draftPath, file_path: result.filePath }, flags);
     if (!flags.quiet) process.stderr.write(`Created: ${result.draftPath}\n`);
@@ -2173,6 +2171,6 @@ async function main(): Promise<void> {
 
 main().catch((e) => {
   const msg = e instanceof Error ? e.message : String(e);
-  process.stderr.write(JSON.stringify({ error: msg }) + "\n");
+  process.stderr.write(`${JSON.stringify({ error: msg })}\n`);
   process.exit(1);
 });

--- a/src/srt.ts
+++ b/src/srt.ts
@@ -19,8 +19,8 @@ export interface SrtCue {
 const TS = /^(\d{1,2}):(\d{2}):(\d{2})[.,](\d{1,3})\s*-->\s*(\d{1,2}):(\d{2}):(\d{2})[.,](\d{1,3})/;
 
 function tsToUs(h: string, m: string, s: string, ms: string): number {
-  const msPadded = (ms + "000").slice(0, 3);
-  return ((parseInt(h) * 3600 + parseInt(m) * 60 + parseInt(s)) * 1000 + parseInt(msPadded)) * 1000;
+  const msPadded = `${ms}000`.slice(0, 3);
+  return ((parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10)) * 1000 + parseInt(msPadded, 10)) * 1000;
 }
 
 export function parseSrt(content: string): SrtCue[] {
@@ -33,7 +33,7 @@ export function parseSrt(content: string): SrtCue[] {
     if (i >= lines.length) break;
     let idx = autoIdx + 1;
     if (/^\d+$/.test(lines[i].trim())) {
-      idx = parseInt(lines[i].trim());
+      idx = parseInt(lines[i].trim(), 10);
       i++;
     }
     if (i >= lines.length) break;

--- a/src/time.ts
+++ b/src/time.ts
@@ -44,15 +44,15 @@ export function parseTimeInput(input: string): number {
     const parts = clean.split(":");
     let totalSec = 0;
     if (parts.length === 3) {
-      totalSec = parseInt(parts[0]) * 3600 + parseInt(parts[1]) * 60 + parseFloat(parts[2]);
+      totalSec = parseInt(parts[0], 10) * 3600 + parseInt(parts[1], 10) * 60 + parseFloat(parts[2]);
     } else {
-      totalSec = parseInt(parts[0]) * 60 + parseFloat(parts[1]);
+      totalSec = parseInt(parts[0], 10) * 60 + parseFloat(parts[1]);
     }
     return (negative ? -1 : 1) * secondsToUs(totalSec);
   }
   // bare number = seconds
   const val = parseFloat(clean);
-  if (isNaN(val)) throw new Error(`Invalid time: ${input}`);
+  if (Number.isNaN(val)) throw new Error(`Invalid time: ${input}`);
   return (negative ? -1 : 1) * secondsToUs(val);
 }
 

--- a/src/wikimedia.ts
+++ b/src/wikimedia.ts
@@ -83,7 +83,7 @@ export function extractFileTitle(u: string): string | null {
     // 1. upload.wikimedia.org direct CDN: /wikipedia/commons/(thumb/)?a/ab/Foo.jpg
     if (host === "upload.wikimedia.org") {
       const m = url.pathname.match(/\/wikipedia\/[^/]+\/(?:thumb\/)?[0-9a-f]\/[0-9a-f]{2}\/([^/]+?)(?:\/\d+px-.+)?$/i);
-      if (m) return "File:" + decodeURIComponent(m[1]);
+      if (m) return `File:${decodeURIComponent(m[1])}`;
       return null;
     }
 
@@ -159,7 +159,7 @@ async function resolvePageimagesApi(apiUrl: string): Promise<string> {
   for (const p of Object.values(pages)) {
     // pageimages returns a pageimage filename (sans File:)
     const file = p.pageimage ?? p.pageprops?.page_image_free;
-    if (file) return "File:" + file;
+    if (file) return `File:${file}`;
   }
   throw new Error(`No pageimage found for titles=${titles}`);
 }

--- a/test/decorators.test.mjs
+++ b/test/decorators.test.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { after, describe, it } from "node:test";
-import { findSegmentByPrefix, loadDraft } from "./helpers/load-fixture.mjs";
 import { spawnCli } from "./helpers/spawn-cli.mjs";
 import { tmpDraft } from "./helpers/tmp-draft.mjs";
 
@@ -121,8 +120,8 @@ describe("capcut enums", () => {
     const jy = spawnCli(["enums", "--transitions", "--jianying"]).json;
     // Different namespaces return different slug sets
     if (cap?.length && jy?.length) {
-      const capSlugs = new Set(cap.map((e) => e.member));
-      const jySlugs = new Set(jy.map((e) => e.member));
+      const _capSlugs = new Set(cap.map((e) => e.member));
+      const _jySlugs = new Set(jy.map((e) => e.member));
       // At least some overlap or difference — they shouldn't be identical objects
       assert.notEqual(JSON.stringify(cap), JSON.stringify(jy));
     }

--- a/test/edit.test.mjs
+++ b/test/edit.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
-import { findSegmentByPrefix, loadDraft } from "./helpers/load-fixture.mjs";
+import { loadDraft } from "./helpers/load-fixture.mjs";
 import { spawnCli } from "./helpers/spawn-cli.mjs";
 import { tmpDraft } from "./helpers/tmp-draft.mjs";
 


### PR DESCRIPTION
## What

Clears the auto-fixable Biome lint debt and pins the Biome version so CI stays deterministic.

### Changes
- **Pin `@biomejs/biome` to exact `2.4.15`** (was `^2.4.15`). A caret range lets a future patch silently change rule severities or import-sort behavior and break CI on unrelated PRs. The `biome.json` schema is already pinned to `2.4.15`, so this just aligns the dependency.
- **Apply `biome check --write --unsafe`** (27 fixes across 9 files), all mechanical and behavior-preserving:
  - `isFinite(n)` > `Number.isFinite(n)` (avoids global coercion)
  - `parseInt(x)` > `parseInt(x, 10)` (explicit radix)
  - string concat > template literals
  - manual null-guards > optional chaining
- `npm test` stays green (**113/113**).

### Left intentionally
The 11 remaining `noAssignInExpressions` warnings are all the idiomatic `(x.y ??= [])` nullish-assign pattern. They're already configured as `warn` (non-blocking) in `biome.json`, and rewriting them would only uglify the code. Left as-is — happy to disable that rule or refactor if you'd prefer.

### Why now
Contributors running `biome check --write --unsafe` (or editors with fix-on-save) were getting ~9 unrelated files rewritten under them, which discouraged running the linter at all. With these landed, the linter is a clean no-op on untouched files.

Note: this does **not** touch `assist/source/organizeImports` enforcement — that's the one error-level check, and it correctly catches unsorted imports in new PRs.
