### PR TITLE
feat: add bash shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 - ✅ JSON (default — pipeable to `jq`)
 - ✅ `-H` / `--human` table mode (human-readable)
 - ✅ `-q` / `--quiet` mode (exit code only)
+- ✅ `completions bash` — generate Bash shell completions
 
 ### Quality (v0.4)
 - ✅ 60+ tests `node:test` suite ([`test/`](./test/)) running against [`test/draft_content.json`](./test/draft_content.json)
@@ -565,6 +566,18 @@ $ capcut set-text ./project a1b2c3 "Hey everyone"
 - `+0.5s` / `-1s` -- relative offset
 - `1:30` -- 1 minute 30 seconds
 - `0:05.5` -- 5.5 seconds
+
+### Shell completions
+
+Generate a Bash completion script:
+
+Install permanently:
+
+```bash
+capcut completions bash >> ~/.bashrc
+```
+
+Completes command names and global flags (`--jianying`, `-H`/`--human`, `-q`/`--quiet`, `-v`/`--version`).
 
 ## How it works
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,63 @@ import { formatDuration, formatTime, parseTimeInput, srtTime } from "./time.js";
 import { translateDraft } from "./translate.js";
 import { detectVersion } from "./version.js";
 
+export const COMMANDS = [
+  "info",
+  "version",
+  "lint",
+  "tracks",
+  "segments",
+  "texts",
+  "set-text",
+  "shift",
+  "shift-all",
+  "speed",
+  "volume",
+  "trim",
+  "opacity",
+  "export-srt",
+  "materials",
+  "segment",
+  "material",
+  "add-audio",
+  "add-video",
+  "add-text",
+  "cut",
+  "keyframe",
+  "transition",
+  "mask",
+  "bg-blur",
+  "text-style",
+  "text-anim",
+  "image-anim",
+  "add-sticker",
+  "mix-mode",
+  "audio-fade",
+  "add-cover",
+  "add-filter",
+  "bubble-text",
+  "add-effect",
+  "save-template",
+  "apply-template",
+  "batch",
+  "import-srt",
+  "import-ass",
+  "text-ranges",
+  "caption",
+  "translate",
+  "migrate",
+  "add-sfx",
+  "chroma",
+  "enums",
+  "doctor",
+  "serve",
+  "decrypt",
+  "export",
+  "init",
+] as const;
+
+const GLOBAL_FLAGS = ["--jianying", "-H", "--human", "-q", "--quiet", "-v", "--version"] as const;
+
 const HELP = `capcut-cli -- fast edits to CapCut projects
 
 Usage: capcut <command> <project> [options]
@@ -477,6 +534,23 @@ const ENUM_FLAG_MAP: Array<{ flag: string; category: Category }> = [
   { flag: "--fonts", category: "fonts" },
   { flag: "--filters", category: "filters" },
 ];
+
+function bashCompletion(): string {
+  const words = [...COMMANDS, ...GLOBAL_FLAGS].join(" ");
+
+  return `# bash completion for capcut
+
+_capcut()
+{
+    local cur
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+
+    COMPREPLY=( $(compgen -W "${words}" -- "$cur") )
+}
+
+complete -F _capcut capcut
+`;
+}
 
 function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
   const positional: string[] = [];
@@ -1996,6 +2070,18 @@ async function main(): Promise<void> {
     process.exit(0);
   }
   const cmd = positional[0];
+
+  if (cmd === "completions") {
+    const shell = positional[1];
+
+    if (shell !== "bash") {
+      die("Usage: capcut completions bash");
+    }
+
+    process.stdout.write(bashCompletion());
+    process.exit(0);
+  }
+
   const projectPath = positional[1];
 
   // `enums` is a pure lookup — no project needed.

--- a/test/completions.test.mjs
+++ b/test/completions.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+describe("capcut completions bash", () => {
+  it("prints bash completion script", () => {
+    const r = spawnCli(["completions", "bash"]);
+
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /complete -F _capcut capcut/);
+    assert.match(r.stdout, /info/);
+    assert.match(r.stdout, /tracks/);
+    assert.match(r.stdout, /--jianying/);
+    assert.match(r.stdout, /--quiet/);
+    assert.match(r.stdout, /--version/);
+    assert.match(r.stdout, /-H/);
+    assert.match(r.stdout, /-q/);
+    assert.match(r.stdout, /-v/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `capcut completions bash` command that generates a Bash completion script.

This implements the Bash portion of the shell completions issue.

## Features

* Completes CLI subcommands
* Completes global flags:

  * `--jianying`
  * `--human`
  * `--quiet`
  * `--version`

## Notes

The issue discussion mentioned leaving `--version` out until the version flag PR was merged. Since that PR has now been merged into `master`, the completion script includes `--version`.

## Testing

* Added completion script generation tests
* Verified Bash completion locally
* All tests pass

## Documentation

* Added a Shell completions subsection under **Commands**
* Added Bash completions to the feature checklist

## Example

```bash
capcut completions bash >> ~/.bashrc
```
