### PR TITLE
feat: add zsh shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 - ✅ JSON (default — pipeable to `jq`)
 - ✅ `-H` / `--human` table mode (human-readable)
 - ✅ `-q` / `--quiet` mode (exit code only)
-- ✅ `completions bash` — generate Bash shell completions
+- ✅ `completions <bash|zsh>` — generate shell completions
 
 ### Quality (v0.4)
 - ✅ 60+ tests `node:test` suite ([`test/`](./test/)) running against [`test/draft_content.json`](./test/draft_content.json)
@@ -573,12 +573,23 @@ $ capcut set-text ./project a1b2c3 "Hey everyone"
 
 ### Shell completions
 
-Generate a Bash completion script:
+Generate shell completions:
 
-Install permanently:
+```bash
+capcut completions <bash|zsh>
+```
+
+#### Bash
 
 ```bash
 capcut completions bash >> ~/.bashrc
+```
+
+#### Zsh
+
+```bash
+mkdir -p ~/.zsh/completions
+capcut completions zsh > ~/.zsh/completions/_capcut
 ```
 
 Completes command names and global flags (`--jianying`, `-H`/`--human`, `-q`/`--quiet`, `-v`/`--version`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -552,6 +552,25 @@ complete -F _capcut capcut
 `;
 }
 
+function zshCompletion(): string {
+  const words = [...COMMANDS, ...GLOBAL_FLAGS].map((w) => `"${w}"`).join("\n    ");
+
+  return `#compdef capcut
+
+_capcut() {
+  local -a commands
+
+  commands=(
+    ${words}
+  )
+
+  _describe 'command' commands
+}
+
+compdef _capcut capcut
+`;
+}
+
 function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
   const positional: string[] = [];
   const flags: Flags = { human: false, quiet: false, batch: false };
@@ -2074,11 +2093,17 @@ async function main(): Promise<void> {
   if (cmd === "completions") {
     const shell = positional[1];
 
-    if (shell !== "bash") {
-      die("Usage: capcut completions bash");
+    switch (shell) {
+      case "bash":
+        process.stdout.write(bashCompletion());
+        break;
+      case "zsh":
+        process.stdout.write(zshCompletion());
+        break;
+      default:
+        die("Usage: capcut completions <bash|zsh>");
     }
 
-    process.stdout.write(bashCompletion());
     process.exit(0);
   }
 

--- a/test/completions.test.mjs
+++ b/test/completions.test.mjs
@@ -18,3 +18,19 @@ describe("capcut completions bash", () => {
     assert.match(r.stdout, /-v/);
   });
 });
+describe("capcut completions zsh", () => {
+  it("prints zsh completion script", () => {
+    const r = spawnCli(["completions", "zsh"]);
+
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /#compdef capcut/);
+    assert.match(r.stdout, /info/);
+    assert.match(r.stdout, /tracks/);
+    assert.match(r.stdout, /--jianying/);
+    assert.match(r.stdout, /--quiet/);
+    assert.match(r.stdout, /--version/);
+    assert.match(r.stdout, /-H/);
+    assert.match(r.stdout, /-q/);
+    assert.match(r.stdout, /-v/);
+  });
+});


### PR DESCRIPTION
## Summary

#8 

Adds Zsh completion support to `capcut completions`.

## Features

* Adds `capcut completions zsh`
* Completes CLI subcommands
* Completes global flags:

  * `--jianying`
  * `-H` / `--human`
  * `-q` / `--quiet`
  * `-v` / `--version`
* Adds tests for Zsh completion generation
* Updates documentation

## Testing

* Verified completion generation locally
* Verified completion loading and completion behavior in Zsh
* `npm test` passes
* `npm run lint` passes

## Example

```bash
capcut completions zsh > ~/.zsh/completions/_capcut
```
