### PR TITLE
feat: add fish shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Status of every feature shipped. ✅ = implemented, ⬜ = roadmap. Section ancho
 - ✅ JSON (default — pipeable to `jq`)
 - ✅ `-H` / `--human` table mode (human-readable)
 - ✅ `-q` / `--quiet` mode (exit code only)
-- ✅ `completions <bash|zsh>` — generate shell completions
+- ✅ `completions <bash|zsh|fish>` — generate shell completions
 
 ### Quality (v0.4)
 - ✅ 60+ tests `node:test` suite ([`test/`](./test/)) running against [`test/draft_content.json`](./test/draft_content.json)
@@ -576,7 +576,7 @@ $ capcut set-text ./project a1b2c3 "Hey everyone"
 Generate shell completions:
 
 ```bash
-capcut completions <bash|zsh>
+capcut completions <bash|zsh|fish>
 ```
 
 #### Bash
@@ -590,6 +590,14 @@ capcut completions bash >> ~/.bashrc
 ```bash
 mkdir -p ~/.zsh/completions
 capcut completions zsh > ~/.zsh/completions/_capcut
+```
+Ensure `~/.zsh/completions` is in your `fpath` before running `compinit`.
+
+#### Fish
+
+```bash
+mkdir -p ~/.config/fish/completions
+capcut completions fish > ~/.config/fish/completions/capcut.fish
 ```
 
 Completes command names and global flags (`--jianying`, `-H`/`--human`, `-q`/`--quiet`, `-v`/`--version`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,6 +571,10 @@ compdef _capcut capcut
 `;
 }
 
+function fishCompletion(): string {
+  return [...COMMANDS, ...GLOBAL_FLAGS].map((word) => `complete -c capcut -f -a "${word}"`).join("\n");
+}
+
 function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
   const positional: string[] = [];
   const flags: Flags = { human: false, quiet: false, batch: false };
@@ -2100,8 +2104,11 @@ async function main(): Promise<void> {
       case "zsh":
         process.stdout.write(zshCompletion());
         break;
+      case "fish":
+        process.stdout.write(fishCompletion());
+        break;
       default:
-        die("Usage: capcut completions <bash|zsh>");
+        die("Usage: capcut completions <bash|zsh|fish>");
     }
 
     process.exit(0);

--- a/test/completions.test.mjs
+++ b/test/completions.test.mjs
@@ -34,3 +34,18 @@ describe("capcut completions zsh", () => {
     assert.match(r.stdout, /-v/);
   });
 });
+
+describe("capcut completions fish", () => {
+  it("prints fish completion script", () => {
+    const r = spawnCli(["completions", "fish"]);
+
+    assert.match(r.stdout, /info/);
+    assert.match(r.stdout, /tracks/);
+    assert.match(r.stdout, /--jianying/);
+    assert.match(r.stdout, /--quiet/);
+    assert.match(r.stdout, /--version/);
+    assert.match(r.stdout, /-H/);
+    assert.match(r.stdout, /-q/);
+    assert.match(r.stdout, /-v/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Fish completion support to `capcut completions`.

### Changes

* Adds `capcut completions fish`
* Completes CLI subcommands
* Completes global flags
* Adds tests for Fish completion generation
* Updates README documentation

### Testing

* Verified completion generation locally
* Verified completion loading and completion behavior in Fish
* `npm test` passes
* `npm run lint` passes

Closes #8.
