### PR TITLE
chore(hooks): rebuild dist before pre-commit tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Pre-commit gate:
 #   1. lint-staged — biome check/format on staged files only
-#   2. fast unit tests — node:test against the built CLI
+#   2. unit tests — node:test against a freshly built CLI
 #
 # Skip with `git commit --no-verify` only when truly necessary; the gate is
 # cheap (lint=<1s, tests<10s on a clean tree) so the bypass should be rare.
@@ -11,5 +11,7 @@ set -e
 # 1. Lint + format staged files
 npx --no-install lint-staged
 
-# 2. Fast unit tests. Build first so dist/ matches src/.
-npm run test:fast --silent 2>&1 | tail -20
+# 2. Unit tests. `npm test` rebuilds dist/ first so it matches src/ — without
+#    the rebuild, test:fast runs against a stale build and can pass-or-fail on
+#    code that isn't what's being committed.
+npm test --silent 2>&1 | tail -20


### PR DESCRIPTION
## Problem
The pre-commit hook ran `npm run test:fast`, which runs `node --test` **without** building. So the suite tested whatever was in `dist/` from a previous build, not the code being committed. The hook comment even claimed "Build first so dist/ matches src/" — but nothing did.

Symptom seen in practice: after the shell-completions work (#18–#20) added new templates, a stale `dist/` made `showTemplates.test.mjs` report failures on an unrelated commit, even though a fresh build is fully green.

## Fix
Use `npm test`, which runs `tsc` (+ copies `enums.json`) before `node --test`, so `dist/` always matches `src/` when the gate runs.

## Verification
Committing this change exercised the updated hook itself: it built and ran the full suite (124/124 pass, ~10s) before the commit was allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)