### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,43 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] — 2026-06-03
+
+Safety, discoverability, and a long-overdue track-order fix. No breaking changes; everything stays zero-dep, JSON-by-default, and pipeable.
 
 ### Added
 
 - **Global `--dry-run`** ([#15](https://github.com/renezander030/capcut-cli/issues/15)) — any draft-mutating command now honors `--dry-run`: it computes and prints the normal JSON result with `"dryRun":true` added, but leaves the draft **and** its `.bak` untouched. Gated centrally in `saveDraft`, so it covers every write command at once. `translate` / `export --batch` keep their existing dry-run behavior.
 - **`restore` command** ([#16](https://github.com/renezander030/capcut-cli/issues/16)) — `capcut restore <project>` undoes the last write by copying `<draft>.bak` back over the draft. Single-step (only one backup generation is kept); exits non-zero with a clear message when no `.bak` exists. Honors `--dry-run`.
-
-### Documentation
-
-- **README** — added a from-source install path and a consolidated Prerequisites note (Node ≥ 18, whisper for `caption`, `ANTHROPIC_API_KEY` for `translate`); a worked-example block for the v0.4/v0.5 commands that had none (`mix-mode`, `audio-fade`, `add-filter`, `bubble-text`, `add-cover`, `add-sfx`, `chroma`, `import-ass`); and a **Troubleshooting** table covering the CapCut-must-be-closed footgun, track-order normalization ([#21](https://github.com/renezander030/capcut-cli/issues/21)), `.bak` recovery, whisper/API-key setup, and the `--fade-out` flag.
+- **Shell completions** ([#18](https://github.com/renezander030/capcut-cli/pull/18), [#19](https://github.com/renezander030/capcut-cli/pull/19), [#20](https://github.com/renezander030/capcut-cli/pull/20)) — `capcut completions <bash|zsh|fish>` generates a completion script for command names and global flags.
 
 ### Fixed
 
 - **Track order scrambled on import** ([#21](https://github.com/renezander030/capcut-cli/issues/21)) — tracks were written in the order edit commands ran, but CapCut lays out the timeline from the tracks-array order, not from per-segment `render_index`, so building a draft incrementally produced a jumbled timeline. `saveDraft` now normalizes the tracks array to the canonical bottom→top layer order (`video → audio → sticker → effect → filter → text`) on every save; the sort is stable so same-type tracks keep their authored order. Also exported as `sortTracks` from the library entry point.
+
+### Documentation
+
+- **README** — added a from-source install path and a consolidated Prerequisites note (Node ≥ 18, whisper for `caption`, `ANTHROPIC_API_KEY` for `translate`); a worked-example block for the v0.4/v0.5 commands that had none (`mix-mode`, `audio-fade`, `add-filter`, `bubble-text`, `add-cover`, `add-sfx`, `chroma`, `import-ass`); `--dry-run` / `restore` usage; and a **Troubleshooting** table covering the CapCut-must-be-closed footgun, track-order normalization, `.bak` recovery, whisper/API-key setup, and the `--fade-out` flag.
+- **`CONTRIBUTING.md`** — build / test / lint commands, the `npm test` pre-commit gate, and PR conventions.
+
+### Internal
+
+- **Pre-commit hook rebuilds `dist/` before tests** ([#23](https://github.com/renezander030/capcut-cli/pull/23)) — the hook ran `test:fast` (no build step), so it could pass-or-fail against a stale `dist/`. It now runs `npm test`, which builds first.
+
+## [0.7.0] — 2026-05-31
+
+### Added
+
+- **`templates` command** ([#13](https://github.com/renezander030/capcut-cli/pull/13)) — `capcut templates` lists the bundled templates (slug + description). JSON by default, `-H` for a table.
+- **Global `--version` / `-v` flag** ([#12](https://github.com/renezander030/capcut-cli/pull/12)) — print the installed CLI version without a subcommand.
+
+### Documentation
+
+- **Independent / non-affiliation disclaimer + trademark notice** — README and metadata clarify the project is unofficial and not affiliated with ByteDance; "CapCut" / "JianYing" are used nominatively.
+
+### Internal
+
+- **Pinned Biome to 2.4.15** ([#14](https://github.com/renezander030/capcut-cli/pull/14)) and cleared auto-fixable lint debt.
 
 ## [0.6.0] — 2026-05-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to capcut-cli
+
+Thanks for considering a contribution. This is a small, zero-dependency project — keep changes in that spirit and they'll land fast.
+
+## Principles
+
+- **Zero runtime dependencies.** The CLI uses Node ≥ 18 built-ins only (`fetch`, `fs`, etc.). A PR that adds a runtime dep to `package.json` will be declined unless there's no built-in path.
+- **JSON in, JSON out.** Every command reads/writes `draft_content.json` directly. Default output is JSON; `-H`/`--human` is the table view; `-q`/`--quiet` is exit-code-only.
+- **No server, no daemon, no state.** Each invocation is independent. HTTP/MCP servers are explicitly out of scope (see `PLAN.md`).
+
+## Development
+
+```bash
+git clone https://github.com/renezander030/capcut-cli
+cd capcut-cli
+npm install
+npm run build        # tsc → dist/ (+ copies enums.json)
+npm test             # build + full node:test suite
+npm run dev -- info ./some-project   # run from source via tsx
+```
+
+- `npm run lint` / `npm run lint:fix` — Biome (pinned version; no autofix debt).
+- `npm run test:fast` — runs the suite **without** rebuilding; only use it when `dist/` is already current.
+
+## Pull requests
+
+1. **Branch** off `master` (`feat/…`, `fix/…`, `docs/…`).
+2. **Add a test** under `test/` — one `.test.mjs` per feature, driven through `spawnCli` against a `tmpDraft()` fixture (see `test/restore.test.mjs` for the pattern). New commands and bug fixes both need coverage.
+3. **Update docs** — README for user-facing changes, `CHANGELOG.md` under a `## [Unreleased]` heading (Keep a Changelog format).
+4. The **pre-commit hook** runs `npm test` (build + full suite) and Biome on staged files. Keep it green; `--no-verify` only for genuine emergencies.
+5. Keep commits focused and the PR description concrete. Reference the issue it closes (`Closes #NN`).
+
+## Filing issues
+
+Bugs: include the command, the relevant slice of `draft_content.json`, the CapCut/JianYing version (`capcut version <project>`), and what you expected vs. saw. Feature requests: describe the workflow it unblocks. A scoped issue with acceptance criteria is the fastest path to a merge.
+
+## License
+
+By contributing you agree your work is licensed under the project's [MIT License](./LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capcut-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capcut-cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "bin": {
         "capcut": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Independent, unofficial CLI to create and edit CapCut projects — build drafts from scratch, add video/audio/text, subtitles, timing, speed, volume, templates, cut long-form to shorts. No API needed. Not affiliated with ByteDance.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts **v0.8.0** and backfills the missing **v0.7.0** changelog section (it was tagged + published but never documented).

## v0.8.0 rolls up the unreleased work
- `--dry-run` on every mutating command (#15)
- `restore` command (#16)
- bash/zsh/fish shell completions (#18–#20)
- track-order normalization fix (#21)
- pre-commit hook rebuilds `dist/` before tests (#23)
- README docs + new `CONTRIBUTING.md`

## Also
- Backfilled `[0.7.0] — 2026-05-31` (templates command, `--version` flag, disclaimer, Biome pin).
- `package.json` → 0.8.0.

After merge: tag `v0.8.0`, GitHub release, and `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)