### PR TITLE
feat: render (ffmpeg proxy preview) + compile (declarative spec → draft)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] — 2026-06-08
+
+Two commands that close the two biggest gaps in a headless CapCut workflow: seeing the result, and authoring a whole draft in one shot. No breaking changes; still zero npm-dep and JSON-by-default. Both shell out to `ffmpeg` only when actually rendering, the same opt-in external-binary pattern `caption` uses for whisper.
+
+### Added
+
+- **`render`** — a low-res **ffmpeg proxy preview** of a draft, so you can watch an edit without opening CapCut. Flattens the main video track (per-segment source trim + speed), scales to a proxy size (`--scale`, default 0.5), mixes every audio-track segment, and optionally burns the text segments in with `--burn-captions`. It is explicitly a preview, **not** CapCut's final render (no multi-track video compositing, no effects/transitions). The ffmpeg command is built by a pure, deterministic `buildRenderPlan` that is unit-tested without invoking ffmpeg; `--dry-run` prints that plan instead of executing (and needs no ffmpeg). Read-only — never mutates the draft.
+- **`compile`** — builds a whole draft from a declarative **JSON spec** (the inverse of `describe`): instead of chaining dozens of mutating `add-*` commands, an agent emits one spec and `compile` constructs the draft atomically via the same proven factory functions the imperative commands use. Times are in seconds (converted to CapCut's microseconds); media paths resolve relative to the spec file. The full spec is validated — and every media file checked to exist — **before** anything is written, so a bad spec fails clean. Writes both `draft_content.json` and `draft_info.json` so every downstream command reads the same data.
+
 ## [0.9.0] — 2026-06-03
 
 Ten new commands/capabilities across inspection, maintenance, composition, and agent-integration. No breaking changes; still zero-dep, JSON-by-default, pipeable.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ How `capcut-cli` differs from the other CapCut / JianYing tooling:
 A capability map; see [Commands](#commands) for syntax.
 
 - **Inspect** — `info` · `tracks` · `materials` · `segments` · `texts`; `segment`/`material <id>` for progressive-disclosure drill-down; `timeline` (ASCII layout); `export-srt`.
-- **Build & add** — `init` a draft, then `add-video` · `add-audio` · `add-text` from local files or [Wikimedia Commons URLs](#wikimedia-commons-phase-5) (license-gated); `add-sticker`, `add-effect`.
+- **Preview** — `render` builds a low-res **ffmpeg proxy** of the timeline (trim + per-segment speed + audio mix, `--burn-captions`) so you can watch an edit without opening CapCut. A preview, not CapCut's final render; `--dry-run` prints the ffmpeg plan.
+- **Build & add** — `init` a draft (or `compile` a whole one from a declarative JSON spec — the inverse of `describe`), then `add-video` · `add-audio` · `add-text` from local files or [Wikimedia Commons URLs](#wikimedia-commons-phase-5) (license-gated); `add-sticker`, `add-effect`.
 - **Edit** — `set-text` · `shift` · `shift-all` · `speed` · `volume` · `opacity` · `trim`; `batch` (many edits, one write); `--dry-run` preview, and `restore` undo (latest `.bak` or `--step N` through snapshot history).
 - **Maintain & compose** — `prune` (drop unreferenced materials) · `relink` (repair broken media paths via `--dir` or `--from`/`--to`) · `projects` (list drafts on disk by name) · `diff` (compare two drafts) · `concat` (stitch drafts into one timeline, id-safe).
 - **Decorate** — `keyframe` · `transition` · `mask` · `bg-blur` · `text-style` · `text-anim` · `image-anim` · `text-ranges` (word-level highlight captions); `mix-mode` · `audio-fade` · `add-filter` · `bubble-text` · `add-cover` · `add-sfx` · `chroma`.
@@ -295,6 +296,39 @@ capcut add-text ./my-short 0s 5s "My Short" --font-size 24 --color "#FFD700"
 `init` creates a valid `draft_content.json` from a built-in template. `add-video` and `add-audio` copy the file into the draft's assets directory so CapCut can find it. Open the project in CapCut and everything links up.
 
 Options for `add-video` / `add-audio`: `--volume <0-1>`, `--template <path>` (custom draft template).
+
+Or describe the whole draft once and `compile` it — the inverse of `describe`, and far more robust for an agent than chaining 30 mutating commands:
+
+```bash
+capcut compile ./short.json --out ./my-short      # spec -> a complete, valid draft
+```
+
+```jsonc
+// short.json — times in seconds; media paths resolve relative to this file
+{
+  "name": "My Short", "width": 1080, "height": 1920, "fps": 30, "ratio": "9:16",
+  "tracks": [
+    { "type": "video", "items": [
+      { "path": "clip1.mp4", "start": 0, "duration": 3 },
+      { "path": "clip2.mp4", "start": 3, "duration": 4 }
+    ] },
+    { "type": "audio", "items": [ { "path": "music.mp3", "start": 0, "duration": 7, "volume": 0.4 } ] },
+    { "type": "text",  "items": [ { "text": "Hook line", "start": 0, "duration": 2, "fontSize": 18, "color": "#FFD700", "y": -0.6 } ] }
+  ]
+}
+```
+
+The whole spec is validated — and every media file checked to exist — **before** anything is written, so a malformed spec fails clean instead of leaving a half-built draft.
+
+### Preview (watch an edit without opening CapCut)
+
+```bash
+capcut render ./my-short                          # -> ./my-short/preview.mp4
+capcut render ./my-short --out p.mp4 --burn-captions --scale 0.5
+capcut render ./my-short --dry-run                # print the ffmpeg plan, run nothing
+```
+
+`render` shells out to **ffmpeg** to build a low-res proxy of the timeline: it flattens the main video track (per-segment source trim + speed), mixes every audio-track segment, and with `--burn-captions` draws the text segments in. It is a *preview*, not CapCut's final render — no multi-track video compositing, no effects/transitions. Read-only: it never touches the draft. Needs `ffmpeg` on `PATH` (or `--ffmpeg-cmd <path>`); `--dry-run` prints the planned ffmpeg invocation and needs no ffmpeg at all.
 
 ### Add
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Independent, unofficial CLI to create and edit CapCut projects — build drafts from scratch, add video/audio/text, subtitles, timing, speed, volume, templates, cut long-form to shorts. No API needed. Not affiliated with ByteDance.",
   "type": "module",
   "bin": {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,0 +1,247 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { loadDraft, saveDraft } from "./draft.js";
+import { addAudio, addText, addVideo, initDraft } from "./factory.js";
+
+/**
+ * Declarative draft compiler: a spec file -> a guaranteed-valid CapCut draft.
+ *
+ * The inverse of `describe`. Instead of an agent chaining 30 mutating commands
+ * (each a place to drift), it emits one declarative spec and `compile` builds
+ * the draft atomically via the same proven factory functions the imperative
+ * `add-*` commands use. The draft is the compile target.
+ *
+ * Times in the spec are in SECONDS (human/LLM friendly); they are converted to
+ * CapCut's microsecond unit here. Media paths are resolved relative to the spec
+ * file's directory unless absolute. The compiler validates the whole spec up
+ * front, so a bad path or shape fails before any draft is written.
+ *
+ * Spec shape (JSON):
+ * {
+ *   "name": "My Short",
+ *   "width": 1080, "height": 1920, "fps": 30, "ratio": "9:16",
+ *   "tracks": [
+ *     { "type": "video", "items": [
+ *       { "path": "clip1.mp4", "start": 0, "duration": 3 },
+ *       { "path": "photo.png", "start": 3, "duration": 2, "type": "photo" }
+ *     ] },
+ *     { "type": "audio", "items": [
+ *       { "path": "music.mp3", "start": 0, "duration": 5, "volume": 0.4 }
+ *     ] },
+ *     { "type": "text", "items": [
+ *       { "text": "Hook line", "start": 0, "duration": 2, "fontSize": 18, "color": "#FFD700", "y": -0.6 }
+ *     ] }
+ *   ]
+ * }
+ */
+
+const US = 1_000_000;
+
+export interface CompileItem {
+  path?: string;
+  text?: string;
+  start: number; // seconds
+  duration?: number; // seconds (video/text required; audio 0 = whole file)
+  volume?: number;
+  fontSize?: number;
+  color?: string;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  type?: "video" | "photo";
+}
+
+export interface CompileTrack {
+  type: "video" | "audio" | "text";
+  name?: string;
+  items: CompileItem[];
+}
+
+export interface CompileSpec {
+  name?: string;
+  width?: number;
+  height?: number;
+  fps?: number;
+  ratio?: string;
+  tracks: CompileTrack[];
+}
+
+export interface CompileOptions {
+  templateDir: string; // bundled _init template
+  outDir: string; // target draft directory (must not already exist)
+  specDir: string; // directory the spec lives in, for relative path resolution
+}
+
+export interface CompileResult {
+  ok: boolean;
+  name: string;
+  draft_path: string;
+  file_path: string;
+  tracks: number;
+  segments: number;
+  duration_us: number;
+  warnings: string[];
+}
+
+const VALID_TRACK_TYPES = new Set(["video", "audio", "text"]);
+
+export function parseSpec(raw: string): CompileSpec {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`compile: spec is not valid JSON: ${(e as Error).message}`);
+  }
+  validateSpec(parsed);
+  return parsed as CompileSpec;
+}
+
+function validateSpec(spec: unknown): asserts spec is CompileSpec {
+  if (!spec || typeof spec !== "object") throw new Error("compile: spec must be a JSON object");
+  const s = spec as Record<string, unknown>;
+  if (!Array.isArray(s.tracks) || s.tracks.length === 0) {
+    throw new Error("compile: spec.tracks must be a non-empty array");
+  }
+  s.tracks.forEach((t, ti) => {
+    if (!t || typeof t !== "object") throw new Error(`compile: tracks[${ti}] must be an object`);
+    const track = t as Record<string, unknown>;
+    if (typeof track.type !== "string" || !VALID_TRACK_TYPES.has(track.type)) {
+      throw new Error(`compile: tracks[${ti}].type must be one of video|audio|text (got ${String(track.type)})`);
+    }
+    if (!Array.isArray(track.items) || track.items.length === 0) {
+      throw new Error(`compile: tracks[${ti}].items must be a non-empty array`);
+    }
+    track.items.forEach((it, ii) => {
+      const item = it as Record<string, unknown>;
+      const where = `tracks[${ti}].items[${ii}]`;
+      if (typeof item.start !== "number" || item.start < 0) {
+        throw new Error(`compile: ${where}.start must be a number >= 0 (seconds)`);
+      }
+      if (track.type === "text") {
+        if (typeof item.text !== "string" || item.text.length === 0) {
+          throw new Error(`compile: ${where}.text is required for text tracks`);
+        }
+        if (typeof item.duration !== "number" || item.duration <= 0) {
+          throw new Error(`compile: ${where}.duration (seconds) is required for text tracks`);
+        }
+      } else {
+        if (typeof item.path !== "string" || item.path.length === 0) {
+          throw new Error(`compile: ${where}.path is required for ${track.type} tracks`);
+        }
+        if (track.type === "video" && (typeof item.duration !== "number" || item.duration <= 0)) {
+          throw new Error(`compile: ${where}.duration (seconds) is required for video tracks`);
+        }
+      }
+    });
+  });
+}
+
+function resolvePath(p: string, specDir: string): string {
+  return isAbsolute(p) ? p : resolve(specDir, p);
+}
+
+export function compileDraft(spec: CompileSpec, opts: CompileOptions): CompileResult {
+  const warnings: string[] = [];
+  // The output DIRECTORY name comes from --out (so the draft lands exactly where
+  // the caller asked); the draft's internal display name comes from spec.name.
+  // These are independent — conflating them writes to the wrong folder.
+  const dirName = basename(opts.outDir);
+  const displayName = spec.name ?? dirName;
+
+  // Pre-flight: every media path must exist before we write anything.
+  for (const track of spec.tracks) {
+    if (track.type === "text") continue;
+    for (const item of track.items) {
+      const abs = resolvePath(item.path as string, opts.specDir);
+      if (!existsSync(abs)) {
+        throw new Error(`compile: media file not found: ${item.path} (resolved: ${abs})`);
+      }
+    }
+  }
+
+  // Seed a fresh draft from the bundled template, then populate it.
+  const { filePath } = initDraft({ name: dirName, templateDir: opts.templateDir, draftsDir: dirname(opts.outDir) });
+  const { draft } = loadDraft(filePath);
+
+  // Canvas + fps from the spec.
+  if (spec.width && spec.height) {
+    draft.canvas_config = {
+      width: spec.width,
+      height: spec.height,
+      ratio: spec.ratio ?? draft.canvas_config?.ratio ?? "original",
+    };
+  }
+  if (spec.fps) draft.fps = spec.fps;
+  draft.name = displayName;
+
+  let segments = 0;
+  let maxEnd = 0;
+
+  for (const track of spec.tracks) {
+    for (const item of track.items) {
+      const start = Math.round(item.start * US);
+      const duration = Math.round((item.duration ?? 0) * US);
+      if (track.type === "video") {
+        addVideo(draft, filePath, {
+          path: resolvePath(item.path as string, opts.specDir),
+          start,
+          duration,
+          type: item.type,
+          width: item.width,
+          height: item.height,
+          trackName: track.name,
+        });
+        maxEnd = Math.max(maxEnd, start + duration);
+      } else if (track.type === "audio") {
+        addAudio(draft, filePath, {
+          path: resolvePath(item.path as string, opts.specDir),
+          start,
+          duration,
+          volume: item.volume,
+          trackName: track.name,
+        });
+        // duration 0 => whole-file; we can't know length without probing, so the
+        // draft duration is driven by the explicit-duration segments.
+        if (duration > 0) maxEnd = Math.max(maxEnd, start + duration);
+      } else {
+        addText(draft, filePath, {
+          text: item.text as string,
+          start,
+          duration,
+          fontSize: item.fontSize,
+          color: item.color,
+          x: item.x,
+          y: item.y,
+          trackName: track.name,
+        });
+        maxEnd = Math.max(maxEnd, start + duration);
+      }
+      segments++;
+    }
+  }
+
+  draft.duration = maxEnd;
+  saveDraft(filePath, draft);
+
+  // The _init template ships BOTH draft_content.json and draft_info.json.
+  // initDraft populated one of them; mirror the finished draft into the sibling
+  // so every downstream command sees the same data regardless of which file it
+  // prefers (findDraft prefers draft_content.json; CapCut reads draft_info.json).
+  const built = readFileSync(filePath, "utf-8");
+  for (const sibling of ["draft_content.json", "draft_info.json"]) {
+    const sp = join(opts.outDir, sibling);
+    if (sp !== filePath && existsSync(sp)) writeFileSync(sp, built, "utf-8");
+  }
+
+  return {
+    ok: true,
+    name: displayName,
+    draft_path: opts.outDir,
+    file_path: filePath,
+    tracks: spec.tracks.length,
+    segments,
+    duration_us: maxEnd,
+    warnings,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { parseAss } from "./ass.js";
 import { captionDraft } from "./caption.js";
 import { removeChroma, setChroma } from "./chroma.js";
+import { type CompileSpec, compileDraft, parseSpec } from "./compile.js";
 import type {
   ImageAnimOptions,
   KeyframeInput,
@@ -78,6 +79,7 @@ import {
 } from "./factory.js";
 import { DEFAULT_LINT_OPTIONS, type LintOptions, lintDraft, lintExitCode, summarize } from "./lint.js";
 import { migrateDraft } from "./migrate.js";
+import { buildRenderPlan, renderDraft } from "./render.js";
 import { serveQueue } from "./serve.js";
 import { addSfx } from "./sfx.js";
 import { parseSrt } from "./srt.js";
@@ -148,6 +150,8 @@ export const COMMANDS = [
   "decrypt",
   "export",
   "init",
+  "compile",
+  "render",
 ] as const;
 
 const GLOBAL_FLAGS = ["--jianying", "-H", "--human", "-q", "--quiet", "-v", "--version", "--dry-run"] as const;
@@ -194,6 +198,23 @@ Create:
              Create a new empty draft from template. Defaults:
                --template   ../CapCutAPI/template (relative to capcut-cli)
                --drafts     ~/Movies/CapCut/User Data/Projects/com.lveditor.draft
+  compile    <spec.json> [--out <draftdir>] [--drafts <dir>]
+             Build a whole draft from a declarative JSON spec (the inverse of
+             describe). Times are in seconds. Media paths resolve relative to
+             the spec file. Validates the full spec before writing anything.
+
+Preview:
+  render     <project> [--out <file.mp4>] [options]
+             Render a low-res ffmpeg PROXY preview of the timeline so you can
+             watch an edit without opening CapCut. Flattens the main video
+             track (trim + per-segment speed) and mixes audio segments; it is
+             NOT CapCut's final render (no multi-track compositing/effects).
+             Options:
+               --scale <f>        Proxy scale of canvas dims (default 0.5)
+               --fps <n>          Output fps (default draft fps)
+               --burn-captions    Draw text-track segments onto the video
+               --ffmpeg-cmd <p>   ffmpeg binary (default ffmpeg)
+               --dry-run          Print the ffmpeg plan; do not execute
 
 Add:
   add-audio  <project> <file-or-wikimedia-url> <start> <duration> [options]
@@ -551,6 +572,9 @@ interface Flags {
   list?: boolean;
   cols?: number;
   names?: boolean;
+  fps?: number;
+  ffmpegCmd?: string;
+  burnCaptions?: boolean;
 }
 
 // Map CLI enum flags -> enums.json category key. Order matters for HELP text.
@@ -793,6 +817,12 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
       flags.cols = parseInt(args[++i], 10);
     } else if (a === "--names") {
       flags.names = true;
+    } else if (a === "--fps" && i + 1 < args.length) {
+      flags.fps = parseFloat(args[++i]);
+    } else if (a === "--ffmpeg-cmd" && i + 1 < args.length) {
+      flags.ffmpegCmd = args[++i];
+    } else if (a === "--burn-captions") {
+      flags.burnCaptions = true;
     } else {
       const hit = ENUM_FLAG_MAP.find((f) => f.flag === a);
       if (hit) {
@@ -2398,6 +2428,8 @@ const SUMMARIES: Record<string, string> = {
   decrypt: "Detect JianYing 6.0+ encryption and explain the workaround.",
   export: "EXPERIMENTAL UI-automated render queue (macOS).",
   init: "Create a new empty draft from a template.",
+  compile: "Build a draft from a declarative JSON spec (the inverse of describe).",
+  render: "Render a low-res ffmpeg proxy preview (trim+speed+audio, --burn-captions); not CapCut's final render.",
 };
 
 const GLOBAL_FLAG_DOCS: Array<{ flag: string; description: string }> = [
@@ -2624,6 +2656,66 @@ function cmdConcat(positional: string[], flags: Flags): void {
   }
 }
 
+// `compile` reads a declarative JSON spec and builds a whole draft via the same
+// factory functions the imperative add-* commands use. Resolves the bundled
+// _init template the same way `init` does.
+function cmdCompile(positional: string[], flags: Flags): void {
+  const specPath = positional[1];
+  if (!specPath) die("Usage: capcut compile <spec.json> [--out <draftdir>] [--drafts <dir>]");
+  if (!existsSync(specPath)) die(`Spec file not found: ${specPath}`);
+
+  let spec: CompileSpec;
+  try {
+    spec = parseSpec(readFileSync(specPath, "utf-8"));
+  } catch (e) {
+    die((e as Error).message);
+  }
+
+  const cliDir = new URL(".", import.meta.url).pathname.replace(/\/dist\/$/, "");
+  const externalTemplate = `${cliDir}/../CapCutAPI/template`;
+  const bundledTemplate = `${cliDir}/templates/_init`;
+  let templateDir = flags.template ?? externalTemplate;
+  if (!flags.template && !existsSync(templateDir) && existsSync(bundledTemplate)) {
+    templateDir = bundledTemplate;
+  }
+
+  // Target draft directory: --out wins; else <drafts>/<spec.name>; else cwd/<spec.name>.
+  const name = spec.name ?? "compiled-draft";
+  const draftsDir = flags.drafts ?? `${process.env.HOME || "~"}/Movies/CapCut/User Data/Projects/com.lveditor.draft`;
+  const outDir = flags.out ? path.resolve(flags.out) : path.resolve(draftsDir, name);
+
+  const result = compileDraft(spec, {
+    templateDir,
+    outDir,
+    specDir: path.dirname(path.resolve(specPath)),
+  });
+  out(result, flags);
+  if (!flags.quiet) process.stderr.write(`Compiled: ${result.draft_path}\n`);
+}
+
+// `render` produces a low-res ffmpeg proxy preview of the timeline. Read-only:
+// it never mutates the draft. With --dry-run it returns the ffmpeg plan without
+// executing, so the filter graph is inspectable (and the path is ffmpeg-free).
+function cmdRender(draft: Draft, filePath: string, flags: Flags): void {
+  const opts = {
+    out: flags.out,
+    scale: flags.scale,
+    fps: flags.fps,
+    ffmpegCmd: flags.ffmpegCmd,
+    burnCaptions: flags.burnCaptions,
+    dryRun: isDryRun(),
+  };
+  if (opts.dryRun) {
+    // Build-only: surface the plan; no ffmpeg needed.
+    const plan = buildRenderPlan(draft, { ...opts, out: opts.out ?? path.join(path.dirname(filePath), "preview.mp4") });
+    out({ ok: true, executed: false, ...plan }, flags);
+    return;
+  }
+  const result = renderDraft(draft, filePath, opts);
+  out(result, flags);
+  if (!flags.quiet) process.stderr.write(`Rendered: ${result.output}\n`);
+}
+
 // --- Main ---
 
 async function main(): Promise<void> {
@@ -2757,6 +2849,12 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  // `compile` builds a brand-new draft from a declarative spec — no existing project.
+  if (cmd === "compile") {
+    cmdCompile(positional, flags);
+    process.exit(0);
+  }
+
   if (!projectPath) die("Missing project path. Run 'capcut --help' for usage.");
 
   const { draft, filePath } = loadDraft(projectPath);
@@ -2773,6 +2871,9 @@ async function main(): Promise<void> {
       break;
     case "timeline":
       cmdTimeline(draft, flags);
+      break;
+    case "render":
+      cmdRender(draft, filePath, flags);
       break;
     case "version":
       cmdVersion(draft, flags);

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,323 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Draft, Segment } from "./draft.js";
+import { extractText } from "./draft.js";
+
+/**
+ * Headless ffmpeg proxy renderer.
+ *
+ * Closes the blind-edit loop: a CapCut draft is opaque JSON you cannot watch
+ * until you open the app. `render` flattens the draft's MAIN video track
+ * (trim source range + apply per-segment speed + scale to a low-res proxy),
+ * mixes every audio-track segment, and optionally burns the text segments in
+ * with `--burn-captions`. The result is a watchable preview MP4 — NOT CapCut's
+ * final render (no multi-track video compositing, no effects/transitions). It
+ * exists to verify "did my edit land where I meant it" without launching CapCut.
+ *
+ * Architecture mirrors `caption` (shell-out to an external binary, here ffmpeg)
+ * and `export --batch` (a deterministic, unit-tested command builder, with the
+ * live run gated behind host availability). `buildRenderPlan` is pure so the
+ * filter graph can be asserted in tests without invoking ffmpeg; `renderDraft`
+ * runs it unless `--dry-run`.
+ */
+
+const US = 1_000_000; // microseconds per second — CapCut's timing unit
+
+export interface RenderOptions {
+  out?: string; // output file; default <draftdir>/preview.mp4
+  scale?: number; // proxy scale factor applied to canvas dims (default 0.5)
+  fps?: number; // output fps override (default draft.fps or 30)
+  ffmpegCmd?: string; // ffmpeg binary (default "ffmpeg")
+  burnCaptions?: boolean; // draw text-track segments onto the video
+  dryRun?: boolean; // build the plan, do not execute ffmpeg
+}
+
+export interface RenderInput {
+  index: number;
+  path: string;
+  kind: "video" | "photo" | "audio";
+}
+
+export interface RenderPlan {
+  output: string;
+  width: number;
+  height: number;
+  fps: number;
+  inputs: RenderInput[];
+  filterComplex: string;
+  args: string[];
+  videoSegments: number;
+  audioSegments: number;
+  textOverlays: number;
+  skipped: Array<{ segmentId: string; reason: string }>;
+}
+
+export interface RenderResult extends RenderPlan {
+  ok: boolean;
+  executed: boolean;
+}
+
+function findVideoPath(draft: Draft, materialId: string): string | undefined {
+  const m = draft.materials.videos?.find((v) => v.id === materialId);
+  return m?.path;
+}
+
+function findAudioPath(draft: Draft, materialId: string): string | undefined {
+  const m = draft.materials.audios?.find((a) => a.id === materialId);
+  return m?.path;
+}
+
+function isPhoto(draft: Draft, materialId: string): boolean {
+  const m = draft.materials.videos?.find((v) => v.id === materialId);
+  return (m?.type ?? "video") === "photo";
+}
+
+// The "main" video track = the first track of type "video" (CapCut lays the
+// timeline out bottom->top from the tracks array, so the first video track is
+// the base layer). Overlay video tracks are not composited in the proxy.
+function mainVideoSegments(draft: Draft): Segment[] {
+  const track = draft.tracks.find((t) => t.type === "video");
+  if (!track) return [];
+  return [...track.segments].sort((a, b) => a.target_timerange.start - b.target_timerange.start);
+}
+
+function audioSegments(draft: Draft): Segment[] {
+  const segs: Segment[] = [];
+  for (const t of draft.tracks) {
+    if (t.type === "audio") segs.push(...t.segments);
+  }
+  return segs.sort((a, b) => a.target_timerange.start - b.target_timerange.start);
+}
+
+function textSegments(draft: Draft): Array<{ seg: Segment; text: string }> {
+  const out: Array<{ seg: Segment; text: string }> = [];
+  for (const t of draft.tracks) {
+    if (t.type !== "text") continue;
+    for (const s of t.segments) {
+      const mat = draft.materials.texts?.find((m) => m.id === s.material_id);
+      const raw = typeof mat?.content === "string" ? extractText(mat.content) : "";
+      if (raw) out.push({ seg: s, text: raw });
+    }
+  }
+  return out.sort((a, b) => a.seg.target_timerange.start - b.seg.target_timerange.start);
+}
+
+// atempo only accepts 0.5..2.0 per filter instance; we keep proxy audio simple
+// and only retime when a single atempo can express it.
+function atempoFor(speed: number): string | null {
+  if (!speed || speed === 1) return null;
+  if (speed >= 0.5 && speed <= 2) return `atempo=${round3(speed)}`;
+  return null; // out of single-stage range — leave audio at source rate for the proxy
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+// drawtext is whitespace/colon/quote sensitive; sanitize aggressively for a proxy.
+function escapeDrawtext(s: string): string {
+  return s
+    .replace(/\\/g, "")
+    .replace(/:/g, " ")
+    .replace(/'/g, "")
+    .replace(/"/g, "")
+    .replace(/%/g, " ")
+    .replace(/\r?\n/g, " ")
+    .trim()
+    .slice(0, 120);
+}
+
+/**
+ * Build the ffmpeg invocation for a draft. Pure and deterministic given the
+ * draft + options (no uuids, no clock) so it can be asserted in tests.
+ */
+export function buildRenderPlan(draft: Draft, opts: RenderOptions): RenderPlan {
+  const scale = opts.scale && opts.scale > 0 ? opts.scale : 0.5;
+  const canvas = draft.canvas_config ?? { width: 1920, height: 1080, ratio: "16:9" };
+  const width = Math.max(2, Math.round((canvas.width * scale) / 2) * 2);
+  const height = Math.max(2, Math.round((canvas.height * scale) / 2) * 2);
+  const fps = opts.fps && opts.fps > 0 ? opts.fps : draft.fps || 30;
+  const output = opts.out ?? join(dirname(""), "preview.mp4");
+
+  const inputs: RenderInput[] = [];
+  const skipped: Array<{ segmentId: string; reason: string }> = [];
+  const inputArgs: string[] = [];
+  const filterParts: string[] = [];
+  const videoLabels: string[] = [];
+
+  // --- video segments (main track) ---
+  const vSegs = mainVideoSegments(draft);
+  for (const seg of vSegs) {
+    const path = findVideoPath(draft, seg.material_id);
+    if (!path) {
+      skipped.push({ segmentId: seg.id, reason: "no material path" });
+      continue;
+    }
+    if (!existsSync(path)) {
+      skipped.push({ segmentId: seg.id, reason: `file missing: ${path}` });
+      continue;
+    }
+    const photo = isPhoto(draft, seg.material_id);
+    const targetDur = round3(seg.target_timerange.duration / US);
+    const idx = inputs.length;
+    inputs.push({ index: idx, path, kind: photo ? "photo" : "video" });
+    if (photo) {
+      inputArgs.push("-loop", "1", "-t", String(targetDur), "-i", path);
+    } else {
+      inputArgs.push("-i", path);
+    }
+    const label = `v${idx}`;
+    if (photo) {
+      filterParts.push(
+        `[${idx}:v]scale=${width}:${height}:force_original_aspect_ratio=decrease,` +
+          `pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=${fps},format=yuv420p,` +
+          `trim=duration=${targetDur},setpts=PTS-STARTPTS[${label}]`,
+      );
+    } else {
+      const srcStart = round3(seg.source_timerange.start / US);
+      const srcDur = round3(seg.source_timerange.duration / US);
+      const speed = seg.speed || 1;
+      const setpts = speed === 1 ? "setpts=PTS-STARTPTS" : `setpts=(PTS-STARTPTS)/${round3(speed)}`;
+      filterParts.push(
+        `[${idx}:v]trim=start=${srcStart}:duration=${srcDur},${setpts},` +
+          `scale=${width}:${height}:force_original_aspect_ratio=decrease,` +
+          `pad=${width}:${height}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=${fps},format=yuv420p[${label}]`,
+      );
+    }
+    videoLabels.push(`[${label}]`);
+  }
+
+  if (videoLabels.length === 0) {
+    throw new Error(
+      "render: no usable video segments found on the main video track " +
+        "(missing material paths or files). Proxy render needs at least one video segment.",
+    );
+  }
+
+  // concat video parts into a single stream
+  let vOut = "vout";
+  if (videoLabels.length === 1) {
+    // single segment: rename its label to vout via a passthrough null filter
+    filterParts.push(`${videoLabels[0]}null[${vOut}]`);
+  } else {
+    filterParts.push(`${videoLabels.join("")}concat=n=${videoLabels.length}:v=1:a=0[${vOut}]`);
+  }
+
+  // --- captions (optional) ---
+  const texts = opts.burnCaptions ? textSegments(draft) : [];
+  let textOverlays = 0;
+  for (const { seg, text } of texts) {
+    const t = escapeDrawtext(text);
+    if (!t) continue;
+    const start = round3(seg.target_timerange.start / US);
+    const end = round3((seg.target_timerange.start + seg.target_timerange.duration) / US);
+    const next = `vt${textOverlays}`;
+    filterParts.push(
+      `[${vOut}]drawtext=text='${t}':fontcolor=white:fontsize=${Math.round(height / 18)}:` +
+        `box=1:boxcolor=black@0.5:boxborderw=8:x=(w-text_w)/2:y=h-(h/6):` +
+        `enable='between(t,${start},${end})'[${next}]`,
+    );
+    vOut = next;
+    textOverlays++;
+  }
+
+  // --- audio segments ---
+  const aSegs = audioSegments(draft);
+  const audioLabels: string[] = [];
+  for (const seg of aSegs) {
+    const path = findAudioPath(draft, seg.material_id);
+    if (!path) {
+      skipped.push({ segmentId: seg.id, reason: "no audio material path" });
+      continue;
+    }
+    if (!existsSync(path)) {
+      skipped.push({ segmentId: seg.id, reason: `file missing: ${path}` });
+      continue;
+    }
+    const idx = inputs.length;
+    inputs.push({ index: idx, path, kind: "audio" });
+    inputArgs.push("-i", path);
+    const srcStart = round3(seg.source_timerange.start / US);
+    const srcDur = round3(seg.source_timerange.duration / US);
+    const startMs = Math.round(seg.target_timerange.start / 1000);
+    const vol = seg.volume ?? 1;
+    const tempo = atempoFor(seg.speed || 1);
+    const chain = [
+      `atrim=start=${srcStart}:duration=${srcDur}`,
+      "asetpts=PTS-STARTPTS",
+      tempo,
+      vol !== 1 ? `volume=${round3(vol)}` : null,
+      `adelay=${startMs}|${startMs}`,
+    ].filter(Boolean);
+    const label = `a${idx}`;
+    filterParts.push(`[${idx}:a]${chain.join(",")}[${label}]`);
+    audioLabels.push(`[${label}]`);
+  }
+
+  let aOut: string | null = null;
+  if (audioLabels.length === 1) {
+    aOut = "aout";
+    filterParts.push(`${audioLabels[0]}anull[${aOut}]`);
+  } else if (audioLabels.length > 1) {
+    aOut = "aout";
+    filterParts.push(`${audioLabels.join("")}amix=inputs=${audioLabels.length}:normalize=0[${aOut}]`);
+  }
+
+  const filterComplex = filterParts.join(";");
+  const args = [
+    "-y",
+    ...inputArgs,
+    "-filter_complex",
+    filterComplex,
+    "-map",
+    `[${vOut}]`,
+    ...(aOut ? ["-map", `[${aOut}]`] : []),
+    "-c:v",
+    "libx264",
+    "-preset",
+    "veryfast",
+    "-crf",
+    "28",
+    "-pix_fmt",
+    "yuv420p",
+    ...(aOut ? ["-c:a", "aac", "-b:a", "128k"] : ["-an"]),
+    "-shortest",
+    output,
+  ];
+
+  return {
+    output,
+    width,
+    height,
+    fps,
+    inputs,
+    filterComplex,
+    args,
+    videoSegments: videoLabels.length,
+    audioSegments: audioLabels.length,
+    textOverlays,
+    skipped,
+  };
+}
+
+export function renderDraft(draft: Draft, filePath: string, opts: RenderOptions): RenderResult {
+  const out = opts.out ?? join(dirname(filePath), "preview.mp4");
+  const plan = buildRenderPlan(draft, { ...opts, out });
+
+  if (opts.dryRun) {
+    return { ...plan, ok: true, executed: false };
+  }
+
+  const cmd = opts.ffmpegCmd ?? "ffmpeg";
+  const r = spawnSync(cmd, plan.args, { encoding: "utf-8", timeout: 600_000 });
+  if (r.error || r.status !== 0) {
+    const stderr = r.stderr?.slice(-600) || r.error?.message || `ffmpeg exited ${r.status}`;
+    throw new Error(
+      `render: ffmpeg failed.\n${stderr}\n` +
+        "Install ffmpeg (`brew install ffmpeg` / `apt install ffmpeg`) or pass --ffmpeg-cmd <path>. " +
+        "Re-run with --dry-run to inspect the filter graph without executing.",
+    );
+  }
+  return { ...plan, ok: true, executed: true };
+}

--- a/test/compile.test.mjs
+++ b/test/compile.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+// Media files only need to EXIST for compile (factory copies them; it never
+// reads their content), so empty placeholder files are enough here.
+function setup() {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-compile-"));
+  writeFileSync(join(dir, "clip1.mp4"), "");
+  writeFileSync(join(dir, "clip2.mp4"), "");
+  writeFileSync(join(dir, "music.mp3"), "");
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function writeSpec(dir, spec) {
+  const p = join(dir, "spec.json");
+  writeFileSync(p, JSON.stringify(spec));
+  return p;
+}
+
+const VALID = {
+  name: "T",
+  width: 720,
+  height: 1280,
+  fps: 30,
+  ratio: "9:16",
+  tracks: [
+    {
+      type: "video",
+      items: [
+        { path: "clip1.mp4", start: 0, duration: 2 },
+        { path: "clip2.mp4", start: 2, duration: 3 },
+      ],
+    },
+    { type: "audio", items: [{ path: "music.mp3", start: 0, duration: 5, volume: 0.4 }] },
+    { type: "text", items: [{ text: "Hook", start: 0, duration: 2, fontSize: 18, color: "#FFD700", y: -0.6 }] },
+  ],
+};
+
+describe("compile", () => {
+  it("builds a valid draft from a JSON spec (both draft files, consistent)", () => {
+    const s = setup();
+    after(s.cleanup);
+    const spec = writeSpec(s.dir, VALID);
+    const out = join(s.dir, "Built");
+    const r = spawnCli(["compile", spec, "--out", out]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.json.ok, true);
+    assert.equal(r.json.tracks, 3);
+    assert.equal(r.json.segments, 4);
+    assert.equal(r.json.duration_us, 5_000_000);
+
+    const content = JSON.parse(readFileSync(join(out, "draft_content.json"), "utf-8"));
+    const info = JSON.parse(readFileSync(join(out, "draft_info.json"), "utf-8"));
+    // Canvas + fps come from the spec.
+    assert.deepEqual(content.canvas_config, { width: 720, height: 1280, ratio: "9:16" });
+    assert.equal(content.fps, 30);
+    assert.equal(content.duration, 5_000_000);
+    // Times converted seconds -> microseconds.
+    const vTrack = content.tracks.find((t) => t.type === "video");
+    assert.equal(vTrack.segments.length, 2);
+    assert.equal(vTrack.segments[0].target_timerange.duration, 2_000_000);
+    // Both files mirror the same built draft so every downstream tool agrees.
+    assert.equal(JSON.stringify(content), JSON.stringify(info));
+  });
+
+  it("produces a draft that passes lint (cross-tool validity)", () => {
+    const s = setup();
+    after(s.cleanup);
+    const spec = writeSpec(s.dir, VALID);
+    const out = join(s.dir, "Built");
+    assert.equal(spawnCli(["compile", spec, "--out", out]).status, 0);
+    const lint = spawnCli(["lint", out, "--no-check-paths"]);
+    assert.equal(lint.status, 0, `lint failed: ${lint.stdout}${lint.stderr}`);
+  });
+
+  it("rejects a spec with no tracks", () => {
+    const s = setup();
+    after(s.cleanup);
+    const spec = writeSpec(s.dir, { name: "X", tracks: [] });
+    const r = spawnCli(["compile", spec, "--out", join(s.dir, "X")]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /tracks must be a non-empty array/);
+  });
+
+  it("fails before writing when a media file is missing", () => {
+    const s = setup();
+    after(s.cleanup);
+    const spec = writeSpec(s.dir, {
+      name: "X",
+      tracks: [{ type: "video", items: [{ path: "does-not-exist.mp4", start: 0, duration: 2 }] }],
+    });
+    const r = spawnCli(["compile", spec, "--out", join(s.dir, "X")]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /media file not found/);
+  });
+
+  it("requires text and duration on text items", () => {
+    const s = setup();
+    after(s.cleanup);
+    const spec = writeSpec(s.dir, {
+      name: "X",
+      tracks: [{ type: "text", items: [{ start: 0, duration: 2 }] }],
+    });
+    const r = spawnCli(["compile", spec, "--out", join(s.dir, "X")]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /\.text is required/);
+  });
+
+  it("rejects invalid JSON with a clear error", () => {
+    const s = setup();
+    after(s.cleanup);
+    const p = join(s.dir, "bad.json");
+    writeFileSync(p, "{not json");
+    const r = spawnCli(["compile", p, "--out", join(s.dir, "X")]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /not valid JSON/);
+  });
+});

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { buildRenderPlan } from "../dist/render.js";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const US = 1_000_000;
+const hasFfmpeg = spawnSync("ffmpeg", ["-version"], { encoding: "utf-8" }).status === 0;
+
+// A minimal but real draft shape: 2 video segments (main track), 1 audio, 1 text.
+function buildDraft(dir, { withText = true } = {}) {
+  const v1 = join(dir, "clip1.mp4");
+  const v2 = join(dir, "clip2.mp4");
+  const a1 = join(dir, "music.mp3");
+  for (const p of [v1, v2, a1]) writeFileSync(p, "");
+  const seg = (matId, start, dur, extra = {}) => ({
+    id: `seg-${matId}`,
+    material_id: matId,
+    target_timerange: { start, duration: dur },
+    source_timerange: { start: 0, duration: dur },
+    speed: 1,
+    volume: 1,
+    visible: true,
+    clip: null,
+    extra_material_refs: [],
+    render_index: 0,
+    ...extra,
+  });
+  const tracks = [
+    {
+      id: "tv",
+      type: "video",
+      name: "video",
+      attribute: 0,
+      segments: [seg("mv1", 0, 2 * US), seg("mv2", 2 * US, 2 * US, { speed: 2 })],
+    },
+    { id: "ta", type: "audio", name: "audio", attribute: 0, segments: [seg("ma1", 0, 4 * US, { volume: 0.4 })] },
+  ];
+  if (withText) {
+    tracks.push({
+      id: "tt",
+      type: "text",
+      name: "captions",
+      attribute: 0,
+      segments: [seg("mt1", 0, 2 * US)],
+    });
+  }
+  return {
+    id: "d",
+    name: "t",
+    duration: 4 * US,
+    fps: 30,
+    canvas_config: { width: 720, height: 1280, ratio: "9:16" },
+    tracks,
+    materials: {
+      videos: [
+        { id: "mv1", path: v1, type: "video", material_name: "clip1.mp4", duration: 2 * US, width: 320, height: 240 },
+        { id: "mv2", path: v2, type: "video", material_name: "clip2.mp4", duration: 2 * US, width: 320, height: 240 },
+      ],
+      audios: [{ id: "ma1", path: a1, name: "music", type: "extract_music", duration: 4 * US }],
+      texts: [{ id: "mt1", type: "text", content: JSON.stringify({ text: "Hook line" }) }],
+      speeds: [],
+      material_animations: [],
+      audio_fades: [],
+      transitions: [],
+    },
+  };
+}
+
+describe("render — plan (buildRenderPlan, pure)", () => {
+  function setup() {
+    const dir = mkdtempSync(join(tmpdir(), "capcut-render-plan-"));
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  it("flattens main video track + mixes audio with correct proxy dims", () => {
+    const s = setup();
+    after(s.cleanup);
+    const plan = buildRenderPlan(buildDraft(s.dir), { out: join(s.dir, "p.mp4"), scale: 0.5 });
+    assert.equal(plan.videoSegments, 2);
+    assert.equal(plan.audioSegments, 1);
+    assert.equal(plan.inputs.length, 3);
+    assert.equal(plan.width, 360); // 720 * 0.5
+    assert.equal(plan.height, 640); // 1280 * 0.5
+    assert.equal(plan.skipped.length, 0);
+    assert.match(plan.filterComplex, /concat=n=2:v=1:a=0/);
+    // per-segment speed shows up as a setpts divisor on the sped-up clip
+    assert.match(plan.filterComplex, /setpts=\(PTS-STARTPTS\)\/2/);
+    assert.ok(plan.args.includes("-filter_complex"));
+    assert.equal(plan.args[plan.args.length - 1], join(s.dir, "p.mp4"));
+  });
+
+  it("omits text overlays unless --burn-captions", () => {
+    const s = setup();
+    after(s.cleanup);
+    const off = buildRenderPlan(buildDraft(s.dir), { out: join(s.dir, "p.mp4") });
+    assert.equal(off.textOverlays, 0);
+    const on = buildRenderPlan(buildDraft(s.dir), { out: join(s.dir, "p.mp4"), burnCaptions: true });
+    assert.equal(on.textOverlays, 1);
+    assert.match(on.filterComplex, /drawtext=text='Hook line'/);
+  });
+
+  it("records skipped segments when material files are missing", () => {
+    const s = setup();
+    after(s.cleanup);
+    const draft = buildDraft(s.dir);
+    rmSync(draft.materials.videos[1].path); // delete clip2
+    const plan = buildRenderPlan(draft, { out: join(s.dir, "p.mp4") });
+    assert.equal(plan.videoSegments, 1);
+    assert.equal(plan.skipped.length, 1);
+    assert.match(plan.skipped[0].reason, /file missing/);
+  });
+
+  it("throws when there is no usable video segment", () => {
+    const s = setup();
+    after(s.cleanup);
+    const draft = buildDraft(s.dir);
+    for (const v of draft.materials.videos) rmSync(v.path);
+    assert.throws(() => buildRenderPlan(draft, { out: join(s.dir, "p.mp4") }), /no usable video segments/);
+  });
+});
+
+describe("render — CLI", () => {
+  function setup() {
+    const dir = mkdtempSync(join(tmpdir(), "capcut-render-cli-"));
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  it("--dry-run returns the plan and writes no file", () => {
+    const s = setup();
+    after(s.cleanup);
+    const draftPath = join(s.dir, "draft_content.json");
+    writeFileSync(draftPath, JSON.stringify(buildDraft(s.dir)));
+    const out = join(s.dir, "preview.mp4");
+    const r = spawnCli(["render", draftPath, "--out", out, "--dry-run"]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.json.executed, false);
+    assert.equal(r.json.videoSegments, 2);
+    assert.ok(!existsSync(out), "dry-run must not write the output file");
+  });
+
+  it("renders a playable proxy MP4 with audio + burned captions", { skip: !hasFfmpeg }, () => {
+    const s = setup();
+    after(s.cleanup);
+    // buildDraft writes empty placeholder files, so build the draft FIRST, then
+    // overwrite those paths with real ffmpeg-generated media to decode.
+    const draft = buildDraft(s.dir);
+    const v1 = join(s.dir, "clip1.mp4");
+    const v2 = join(s.dir, "clip2.mp4");
+    const a1 = join(s.dir, "music.mp3");
+    const gen = (args) => spawnSync("ffmpeg", ["-y", "-loglevel", "error", ...args], { encoding: "utf-8" });
+    gen(["-f", "lavfi", "-i", "testsrc=duration=2:size=320x240:rate=15", "-pix_fmt", "yuv420p", v1]);
+    gen(["-f", "lavfi", "-i", "testsrc2=duration=2:size=320x240:rate=15", "-pix_fmt", "yuv420p", v2]);
+    gen(["-f", "lavfi", "-i", "sine=frequency=440:duration=4", a1]);
+    const draftPath = join(s.dir, "draft_content.json");
+    writeFileSync(draftPath, JSON.stringify(draft));
+
+    const out = join(s.dir, "preview.mp4");
+    const r = spawnCli(["render", draftPath, "--out", out, "--burn-captions"], { timeout: 120_000 });
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(r.json.executed, true);
+    assert.ok(existsSync(out) && statSync(out).size > 0, "expected a non-empty proxy file");
+
+    // Probe: the proxy must carry both a video and an audio stream.
+    const probe = spawnSync("ffprobe", ["-v", "error", "-show_entries", "stream=codec_type", "-of", "csv=p=0", out], {
+      encoding: "utf-8",
+    });
+    assert.match(probe.stdout, /video/);
+    assert.match(probe.stdout, /audio/);
+  });
+});


### PR DESCRIPTION
Adds the two highest-utility next commands on top of v0.9, both validated end-to-end before merge.

## `render` — watch an edit without opening CapCut
A low-res **ffmpeg proxy** of the timeline: flattens the main video track (per-segment source trim + speed), mixes every audio-track segment, and with `--burn-captions` draws the text segments in. Explicitly a *preview*, not CapCut's final render (no multi-track compositing/effects). Read-only — never mutates the draft.

- The ffmpeg invocation is built by a pure, deterministic `buildRenderPlan` that is unit-tested **without** invoking ffmpeg.
- `--dry-run` prints that plan and needs no ffmpeg at all.
- ffmpeg is an opt-in shell-out, only when actually rendering — same pattern `caption` uses for whisper. Still zero npm-dep.

```bash
capcut render ./my-short --burn-captions       # -> ./my-short/preview.mp4
capcut render ./my-short --dry-run             # print the ffmpeg plan, run nothing
```

## `compile` — build a whole draft from a declarative JSON spec
The inverse of `describe`: instead of chaining 30 mutating `add-*` commands (each a place to drift), an agent emits one spec and `compile` constructs the draft atomically via the same factory functions the imperative commands use.

- Times in seconds (converted to CapCut microseconds); media paths resolve relative to the spec file.
- Validates the full spec **and checks every media file exists before writing anything** — a bad spec fails clean.
- Mirrors the result to both `draft_content.json` and `draft_info.json` so every downstream command reads the same data.

```bash
capcut compile ./short.json --out ./my-short
```

## Verification
- **171 tests pass, 0 fail** (12 new: 6 `compile`, 6 `render` incl. a real ffmpeg render gated on host availability + a pure-plan suite).
- `compile` output passes `capcut lint` (cross-tool validity check).
- Pre-commit gate (biome + full `npm test`) green.
- Two real bugs found and fixed during verification: `compile` was writing to `draftsDir/spec.name` instead of `--out` (dir name vs draft display-name conflation), and the dual `draft_content.json`/`draft_info.json` template files are now kept consistent.

Bumps to **v0.10.0**; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)