### PR TITLE
docs: list render + compile in the comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ How `capcut-cli` differs from the other CapCut / JianYing tooling:
 |---|:---:|:---:|:---:|:---:|:---:|
 | Inspect drafts (`info` / `tracks` / `materials` / `segments` / `texts`) | partial | partial | ❌ | ❌ | ✅ |
 | Create drafts from scratch | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Declarative spec → draft (one `compile`, not 30 imperative calls) | ❌ | ❌ | ❌ | ❌ | ✅ (v0.10.0) |
+| Preview an edit without opening CapCut (local ffmpeg proxy) | ❌ | ❌ | ❌ | ❌ | ✅ (v0.10.0) |
 | Decorators (`keyframe` / `transition` / `mask` / `text-anim` / `image-anim`) | ✅ | ✅ | ✅ | ✅ | ✅ (v0.3.0) |
 | SRT import → per-cue text segments | ❌ | ❌ | ✅ | ❌ | ✅ (v0.3.0) |
 | Multi-style text (word-level highlight captions) | partial | partial | ❌ | ❌ | ✅ (v0.3.0) |


### PR DESCRIPTION
The two v0.10.0 commands (`render`, `compile`) were already in the README capability map and command worked-examples, but missing from the **comparison matrix** — where readers scan to see what's unique vs the other CapCut/JianYing tooling.

Adds two rows, both differentiators no other listed tool offers:
- **Declarative spec → draft** (`compile`) — one spec instead of 30 imperative calls.
- **Preview an edit without opening CapCut** (`render`, local ffmpeg proxy).

Docs-only. (No release-notes section added by design — line 31 already links the changelog + releases as the single source of truth.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)