### PR TITLE
feat(add-video): auto-detect source dimensions via ffprobe (#32)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import {
 } from "./factory.js";
 import { DEFAULT_LINT_OPTIONS, type LintOptions, lintDraft, lintExitCode, summarize } from "./lint.js";
 import { migrateDraft } from "./migrate.js";
+import { probeVideoDimensions } from "./probe.js";
 import { buildRenderPlan, renderDraft } from "./render.js";
 import { serveQueue } from "./serve.js";
 import { addSfx } from "./sfx.js";
@@ -196,7 +197,7 @@ Detail (drill into one item):
 Create:
   init       <name> [--template <dir>] [--drafts <dir>]
              Create a new empty draft from template. Defaults:
-               --template   ../CapCutAPI/template (relative to capcut-cli)
+               --template   bundled minimal template (no external repo needed)
                --drafts     ~/Movies/CapCut/User Data/Projects/com.lveditor.draft
   compile    <spec.json> [--out <draftdir>] [--drafts <dir>]
              Build a whole draft from a declarative JSON spec (the inverse of
@@ -231,6 +232,10 @@ Add:
              add-audio). Type auto-detected from extension.
              Options:
                --track-name <s>   Track name (default: "video")
+               --width <n>        Source width in px (default: auto-probed via
+                                  ffprobe, else 1920)
+               --height <n>       Source height in px (default: auto-probed via
+                                  ffprobe, else 1080)
                --force-license    Bypass refusal on restrictive/unknown license
 
   add-text   <project> <start> <duration> <text> [options]
@@ -470,6 +475,8 @@ interface Flags {
   x?: number;
   y?: number;
   trackName?: string;
+  width?: number;
+  height?: number;
   volume?: number;
   template?: string;
   drafts?: string;
@@ -659,6 +666,10 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
       flags.y = parseFloat(args[++i]);
     } else if (a === "--track-name" && i + 1 < args.length) {
       flags.trackName = args[++i];
+    } else if (a === "--width" && i + 1 < args.length) {
+      flags.width = parseFloat(args[++i]);
+    } else if (a === "--height" && i + 1 < args.length) {
+      flags.height = parseFloat(args[++i]);
     } else if (a === "--volume" && i + 1 < args.length) {
       flags.volume = parseFloat(args[++i]);
     } else if (a === "--template" && i + 1 < args.length) {
@@ -1262,11 +1273,34 @@ async function cmdAddVideo(draft: Draft, filePath: string, positional: string[],
   const absPath = localPath.startsWith("/") ? localPath : `${process.cwd()}/${localPath}`;
   const start = parseTimeInput(startStr);
   const duration = parseTimeInput(durationStr);
+
+  // Resolve the source dimensions. Explicit --width/--height always win; otherwise
+  // probe the file with ffprobe (best-effort) so portrait sources are not forced
+  // into the 1920x1080 landscape default. If neither is available, addVideo falls
+  // back to 1920x1080 and we surface a warning so the user can override.
+  let width = flags.width;
+  let height = flags.height;
+  let dimensionSource = width && height ? "flags" : "default";
+  let dimensionWarning: string | undefined;
+  if (!(width && height)) {
+    const probed = probeVideoDimensions(absPath);
+    if (probed) {
+      width = probed.width;
+      height = probed.height;
+      dimensionSource = "ffprobe";
+    } else {
+      dimensionWarning =
+        "Could not detect dimensions (ffprobe unavailable or failed); defaulted to 1920x1080. Pass --width/--height to override.";
+    }
+  }
+
   const opts: AddVideoOptions = {
     path: absPath,
     start,
     duration,
     trackName: flags.trackName,
+    width,
+    height,
   };
   const result = addVideo(draft, filePath, opts);
   saveDraft(filePath, draft);
@@ -1278,6 +1312,9 @@ async function cmdAddVideo(draft: Draft, filePath: string, positional: string[],
     path: absPath,
     start_us: start,
     duration_us: duration,
+    width: width ?? 1920,
+    height: height ?? 1080,
+    dimension_source: dimensionSource,
   };
   if (asset) {
     payload.wikimedia = {
@@ -1292,7 +1329,8 @@ async function cmdAddVideo(draft: Draft, filePath: string, positional: string[],
       mime: asset.mime,
     };
   }
-  if (warning) payload.warning = warning;
+  const warnings = [warning, dimensionWarning].filter(Boolean);
+  if (warnings.length) payload.warning = warnings.join(" ");
   out(payload, flags);
 }
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -1,0 +1,115 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Best-effort media dimension probe.
+ *
+ * `add-video` previously hardcoded 1920x1080 for every source, so a portrait
+ * (1080x1920) clip landed in the draft as landscape and CapCut rendered it
+ * letterboxed/cropped. This module shells out to `ffprobe` to read the real
+ * stored dimensions AND the display rotation, then returns the dimensions as
+ * they should appear on screen.
+ *
+ * Architecture mirrors `render`/`caption`: the parsing + rotation math is a
+ * pure, deterministic function (`parseProbeStreams` / `displayDimensions`)
+ * that tests can assert without invoking ffprobe; the live shell-out
+ * (`probeVideoDimensions`) is best-effort and returns null whenever ffprobe is
+ * missing, errors, or emits something we cannot parse. Callers fall back to
+ * their previous defaults on null, so a host without ffprobe is never worse
+ * off than before — it just does not get auto-detection.
+ */
+
+export interface ProbedDimensions {
+  width: number;
+  height: number;
+  rotation: number; // normalized 0/90/180/270, clockwise
+}
+
+/**
+ * Parse `ffprobe -show_streams -print_format json` output and pull the stored
+ * width/height plus display rotation off the first video stream. Rotation is
+ * read from `tags.rotate` (older ffmpeg) or a Display Matrix `side_data_list`
+ * entry (newer ffmpeg), normalized to 0/90/180/270 clockwise. Returns null if
+ * the JSON has no usable video stream.
+ */
+export function parseProbeStreams(json: string): ProbedDimensions | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  const streams = (parsed as { streams?: unknown }).streams;
+  if (!Array.isArray(streams)) return null;
+
+  const video = streams.find(
+    (s) =>
+      s &&
+      typeof s === "object" &&
+      (s as Record<string, unknown>).codec_type === "video" &&
+      Number.isFinite(Number((s as Record<string, unknown>).width)) &&
+      Number.isFinite(Number((s as Record<string, unknown>).height)),
+  ) as Record<string, unknown> | undefined;
+  if (!video) return null;
+
+  const width = Number(video.width);
+  const height = Number(video.height);
+  if (!(width > 0) || !(height > 0)) return null;
+
+  let rotation = 0;
+  const tags = video.tags as Record<string, unknown> | undefined;
+  if (tags && tags.rotate !== undefined && Number.isFinite(Number(tags.rotate))) {
+    rotation = Number(tags.rotate);
+  } else if (Array.isArray(video.side_data_list)) {
+    for (const sd of video.side_data_list as Array<Record<string, unknown>>) {
+      if (sd && Number.isFinite(Number(sd.rotation))) {
+        rotation = Number(sd.rotation);
+        break;
+      }
+    }
+  }
+
+  return { width, height, rotation: normalizeRotation(rotation) };
+}
+
+/** Normalize any degree value (negative or >360) to one of 0/90/180/270. */
+export function normalizeRotation(rotation: number): number {
+  const r = ((Math.round(rotation) % 360) + 360) % 360;
+  // Snap to the nearest quarter turn; ffprobe occasionally reports e.g. -90.
+  return (Math.round(r / 90) * 90) % 360;
+}
+
+/**
+ * Apply rotation to stored dimensions to get on-screen (display) dimensions.
+ * A 90/270 degree rotation swaps width and height.
+ */
+export function displayDimensions(d: ProbedDimensions): { width: number; height: number } {
+  const rot = normalizeRotation(d.rotation);
+  if (rot === 90 || rot === 270) return { width: d.height, height: d.width };
+  return { width: d.width, height: d.height };
+}
+
+/**
+ * Live, best-effort probe. Runs ffprobe against `path` and returns the
+ * on-screen dimensions, or null if ffprobe is unavailable/fails/unparseable.
+ * `ffprobeCmd` overrides the binary (mirrors render's `--ffmpeg-cmd`).
+ */
+export function probeVideoDimensions(
+  path: string,
+  ffprobeCmd = "ffprobe",
+): { width: number; height: number; rotation: number } | null {
+  let r: ReturnType<typeof spawnSync>;
+  try {
+    r = spawnSync(
+      ffprobeCmd,
+      ["-v", "quiet", "-print_format", "json", "-show_streams", "-select_streams", "v:0", path],
+      { encoding: "utf-8", timeout: 30_000 },
+    );
+  } catch {
+    return null;
+  }
+  if (r.status !== 0 || typeof r.stdout !== "string") return null;
+  const parsed = parseProbeStreams(r.stdout);
+  if (!parsed) return null;
+  const { width, height } = displayDimensions(parsed);
+  return { width, height, rotation: parsed.rotation };
+}

--- a/test/probe.test.mjs
+++ b/test/probe.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { displayDimensions, normalizeRotation, parseProbeStreams, probeVideoDimensions } from "../dist/probe.js";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+const hasFfprobe = spawnSync("ffprobe", ["-version"], { encoding: "utf-8" }).status === 0;
+
+const REAL_MEDIA = join(process.cwd(), "media", "two-sisters-vietnam-short.mp4"); // 64x64
+
+describe("probe: parseProbeStreams", () => {
+  it("reads width/height off the first video stream", () => {
+    const json = JSON.stringify({ streams: [{ codec_type: "video", width: 1920, height: 1080 }] });
+    assert.deepEqual(parseProbeStreams(json), { width: 1920, height: 1080, rotation: 0 });
+  });
+
+  it("reads rotation from tags.rotate (older ffmpeg)", () => {
+    const json = JSON.stringify({
+      streams: [{ codec_type: "video", width: 1920, height: 1080, tags: { rotate: "90" } }],
+    });
+    assert.deepEqual(parseProbeStreams(json), { width: 1920, height: 1080, rotation: 90 });
+  });
+
+  it("reads rotation from a Display Matrix side_data entry (newer ffmpeg)", () => {
+    const json = JSON.stringify({
+      streams: [
+        {
+          codec_type: "video",
+          width: 1920,
+          height: 1080,
+          side_data_list: [{ side_data_type: "Display Matrix", rotation: -90 }],
+        },
+      ],
+    });
+    assert.deepEqual(parseProbeStreams(json), { width: 1920, height: 1080, rotation: 270 });
+  });
+
+  it("skips audio-only streams and returns null", () => {
+    const json = JSON.stringify({ streams: [{ codec_type: "audio" }] });
+    assert.equal(parseProbeStreams(json), null);
+  });
+
+  it("returns null on malformed JSON", () => {
+    assert.equal(parseProbeStreams("not json"), null);
+  });
+});
+
+describe("probe: displayDimensions", () => {
+  it("leaves landscape unchanged at 0/180", () => {
+    assert.deepEqual(displayDimensions({ width: 1920, height: 1080, rotation: 0 }), {
+      width: 1920,
+      height: 1080,
+    });
+    assert.deepEqual(displayDimensions({ width: 1920, height: 1080, rotation: 180 }), {
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it("swaps W/H for a 90/270 rotation (portrait phone clip)", () => {
+    assert.deepEqual(displayDimensions({ width: 1920, height: 1080, rotation: 90 }), {
+      width: 1080,
+      height: 1920,
+    });
+    assert.deepEqual(displayDimensions({ width: 1920, height: 1080, rotation: 270 }), {
+      width: 1080,
+      height: 1920,
+    });
+  });
+});
+
+describe("probe: normalizeRotation", () => {
+  it("normalizes negatives and overflows to 0/90/180/270", () => {
+    assert.equal(normalizeRotation(-90), 270);
+    assert.equal(normalizeRotation(450), 90);
+    assert.equal(normalizeRotation(360), 0);
+    assert.equal(normalizeRotation(-270), 90);
+  });
+});
+
+describe("add-video: dimension resolution", () => {
+  const fix = tmpDraft();
+  after(() => fix.cleanup());
+
+  function dummyMedia(name) {
+    const p = join(fix.dir, name);
+    writeFileSync(p, "not a real video");
+    return p;
+  }
+
+  it("honors explicit --width/--height (no probe needed)", () => {
+    const media = dummyMedia("flags.mp4");
+    const r = spawnCli(["add-video", fix.path, media, "0", "1s", "--width", "1080", "--height", "1920"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.width, 1080);
+    assert.equal(r.json.height, 1920);
+    assert.equal(r.json.dimension_source, "flags");
+  });
+
+  it("falls back to 1920x1080 + warning when dimensions cannot be probed", () => {
+    const media = dummyMedia("garbage.mp4");
+    const r = spawnCli(["add-video", fix.path, media, "0", "1s"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.width, 1920);
+    assert.equal(r.json.height, 1080);
+    assert.equal(r.json.dimension_source, "default");
+    assert.match(r.json.warning, /ffprobe|--width/);
+  });
+
+  it("auto-probes a real file via ffprobe", (t) => {
+    if (!hasFfprobe) return t.skip("ffprobe not installed");
+    const probed = probeVideoDimensions(REAL_MEDIA);
+    if (!probed) return t.skip("test media not available");
+    const r = spawnCli(["add-video", fix.path, REAL_MEDIA, "0", "1s", "--track-name", "probe"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.dimension_source, "ffprobe");
+    assert.equal(r.json.width, probed.width);
+    assert.equal(r.json.height, probed.height);
+  });
+});


### PR DESCRIPTION
## Problem

Reported in #32 (by @YacAttack): `add-video` mis-stored a 1080×1920 portrait file as 1920×1080. Root cause: `addVideo` hardcoded `width = opts.width ?? 1920; height = opts.height ?? 1080` and the `add-video` command never populated those options — so every source was recorded as landscape and CapCut letterboxed/cropped portrait clips.

## Fix

`add-video` now resolves dimensions in priority order:

- explicit `--width`/`--height` flags always win
- otherwise probe the file with `ffprobe` (best-effort), applying display rotation so portrait phone clips (`tags.rotate` 90/270, or a Display Matrix `side_data` entry) come out upright
- if ffprobe is missing or fails, fall back to 1920×1080 as before and emit a `warning` telling the user to pass `--width/--height`

New `src/probe.ts` mirrors the `render`/`caption` pattern: a pure, unit-tested parser (`parseProbeStreams` / `displayDimensions` / `normalizeRotation`) plus a best-effort live shell-out (`probeVideoDimensions`) that returns `null` on any failure. Hosts without ffprobe are never worse off than before, they just don't get auto-detection.

Output now reports `width`, `height`, and `dimension_source` (`flags` | `ffprobe` | `default`).

Also fixes the stale `init --template` help text (it referenced `../CapCutAPI/template`; the bundled template has been the default since v0.10).

## Tests

`test/probe.test.mjs`: pure parser/rotation cases (landscape, `tags.rotate`, Display Matrix side_data, audio-only, malformed JSON, rotation normalization), plus CLI tests for the `--width/--height` override, the ffprobe-absent fallback + warning, and a live ffprobe probe gated on host availability. Full suite: 184/184 green, lint at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)