### PR TITLE
feat(lint): --fix repairs mechanically-fixable draft defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `lint <project> --fix` — auto-repair mechanically-fixable draft defects (`cue-too-long`, `caption-overlap`). Trims over-long captions to the configured cap and shortens overlapping caption pairs so each ends where the next begins. Writes atomically with a `.bak` snapshot; combine with `--dry-run` to preview without touching the draft. Non-fixable issues (`missing-material`, `missing-file`, `line-too-long`, `caption-gap-too-small`) are still reported and continue to drive the exit code. Closes #40.
+
 ## [0.12.0] — 2026-06-27
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ import {
   uuid,
 } from "./factory.js";
 import { sanitizeDraftBundle } from "./fixture.js";
-import { DEFAULT_LINT_OPTIONS, type LintOptions, lintDraft, lintExitCode, summarize } from "./lint.js";
+import { DEFAULT_LINT_OPTIONS, fixDraft, type LintOptions, lintDraft, lintExitCode, summarize } from "./lint.js";
 import { migrateDraft } from "./migrate.js";
 import { probeMedia } from "./probe.js";
 import { runQuickstart } from "./quickstart.js";
@@ -194,6 +194,9 @@ Overview (start here):
                --max-cue-secs <n>  Caption duration cap (default 7)
                --min-gap-ms <n>    Min gap between captions (default 0)
                --no-check-paths    Skip local-file existence checks
+               --fix               Auto-repair mechanically-fixable issues
+                                   (cue-too-long, caption-overlap). Combine
+                                   with --dry-run to preview without writing.
              Exit codes: 0 clean · 1 warnings · 2 errors
 
 Browse:
@@ -576,6 +579,7 @@ interface Flags {
   maxCueSecs?: number;
   minGapMs?: number;
   noCheckPaths?: boolean;
+  fix?: boolean;
   // caption
   audio?: string;
   fromSegment?: string;
@@ -841,6 +845,8 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
       flags.minGapMs = parseFloat(args[++i]);
     } else if (a === "--no-check-paths") {
       flags.noCheckPaths = true;
+    } else if (a === "--fix") {
+      flags.fix = true;
     } else if (a === "--audio" && i + 1 < args.length) {
       flags.audio = args[++i];
     } else if (a === "--from-segment" && i + 1 < args.length) {
@@ -2018,7 +2024,7 @@ function cmdVersion(draft: Draft, flags: Flags): void {
   }
 }
 
-function cmdLint(draft: Draft, flags: Flags): { exitCode: number } {
+function cmdLint(draft: Draft, filePath: string, flags: Flags): { exitCode: number } {
   const opts: LintOptions = {
     maxCharsPerLine: flags.maxChars ?? DEFAULT_LINT_OPTIONS.maxCharsPerLine,
     maxCueDurationUs:
@@ -2027,6 +2033,37 @@ function cmdLint(draft: Draft, flags: Flags): { exitCode: number } {
       flags.minGapMs !== undefined ? flags.minGapMs * 1000 : DEFAULT_LINT_OPTIONS.minGapBetweenCaptionsUs,
     checkLocalPaths: flags.noCheckPaths ? false : DEFAULT_LINT_OPTIONS.checkLocalPaths,
   };
+
+  if (flags.fix) {
+    const { fixed, remaining } = fixDraft(draft, opts);
+    // Only write if we actually repaired something. --dry-run (global) is
+    // honored by saveDraft, which leaves the file and its .bak untouched.
+    if (fixed.length > 0) saveDraft(filePath, draft);
+    const summary = summarize(remaining);
+    const exitCode = lintExitCode(summary);
+    if (flags.human) {
+      if (fixed.length === 0 && remaining.length === 0) {
+        console.log("OK — no issues found");
+      } else {
+        for (const i of fixed) {
+          const loc = i.location?.segment_id ? ` [${i.location.segment_id.slice(0, 8)}]` : "";
+          console.log(`FIXED   ${i.code.padEnd(22)}${loc}  ${i.message}`);
+        }
+        for (const i of remaining) {
+          const loc = i.location?.segment_id ? ` [${i.location.segment_id.slice(0, 8)}]` : "";
+          console.log(`${i.severity.toUpperCase().padEnd(7)} ${i.code.padEnd(22)}${loc}  ${i.message}`);
+        }
+        console.log("");
+        console.log(
+          `${fixed.length} fixed · ${summary.errors} errors · ${summary.warnings} warnings · ${summary.info} info`,
+        );
+      }
+    } else {
+      out({ ok: summary.errors === 0, fixed, summary, issues: remaining }, flags);
+    }
+    return { exitCode };
+  }
+
   const issues = lintDraft(draft, opts);
   const summary = summarize(issues);
   const exitCode = lintExitCode(summary);
@@ -3193,7 +3230,7 @@ async function main(): Promise<void> {
       cmdVersion(draft, flags);
       break;
     case "lint": {
-      const { exitCode } = cmdLint(draft, flags);
+      const { exitCode } = cmdLint(draft, filePath, flags);
       process.exit(exitCode);
       break;
     }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -8,6 +8,7 @@ export interface LintIssue {
   severity: Severity;
   code: string;
   message: string;
+  fixable: boolean;
   location?: {
     track?: string;
     segment_id?: string;
@@ -15,6 +16,10 @@ export interface LintIssue {
     path?: string;
   };
 }
+
+// Codes that lintDraft can mechanically repair via fixDraft. Any issue whose
+// code appears here is emitted with fixable:true.
+const FIXABLE_CODES = new Set<string>(["cue-too-long", "caption-overlap"]);
 
 export interface LintOptions {
   maxCharsPerLine: number;
@@ -41,6 +46,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
         severity: "error",
         code: "missing-material",
         message: `Segment ${shortId(s.id)} references material ${shortId(s.material_id)} that does not exist in any materials.*`,
+        fixable: FIXABLE_CODES.has("missing-material"),
         location: { track: seg.track.name, segment_id: s.id, material_id: s.material_id },
       });
     }
@@ -58,6 +64,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
           severity: "warning",
           code: "cue-too-long",
           message: `Caption ${shortId(s.id)} runs ${Math.round(s.target_timerange.duration / 1000)}ms (>${opts.maxCueDurationUs / 1_000_000}s)`,
+          fixable: FIXABLE_CODES.has("cue-too-long"),
           location: { track: track.name, segment_id: s.id },
         });
       }
@@ -68,6 +75,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
             severity: "warning",
             code: "line-too-long",
             message: `Caption ${shortId(s.id)} has ${line.length}-char line (>${opts.maxCharsPerLine}): "${line.slice(0, 50)}…"`,
+            fixable: FIXABLE_CODES.has("line-too-long"),
             location: { track: track.name, segment_id: s.id },
           });
           break;
@@ -83,6 +91,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
             severity: "error",
             code: "caption-overlap",
             message: `Captions ${shortId(s.id)} and ${shortId(next.id)} overlap by ${Math.round(-gap / 1000)}ms on track "${track.name}"`,
+            fixable: FIXABLE_CODES.has("caption-overlap"),
             location: { track: track.name, segment_id: s.id },
           });
         } else if (gap > 0 && gap < opts.minGapBetweenCaptionsUs) {
@@ -90,6 +99,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
             severity: "warning",
             code: "caption-gap-too-small",
             message: `Captions ${shortId(s.id)} and ${shortId(next.id)} are ${Math.round(gap / 1000)}ms apart (<${opts.minGapBetweenCaptionsUs / 1000}ms)`,
+            fixable: FIXABLE_CODES.has("caption-gap-too-small"),
             location: { track: track.name, segment_id: s.id },
           });
         }
@@ -108,6 +118,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
             severity: "error",
             code: "missing-file",
             message: `Material ${shortId(m.id)} (${kind}) references file that doesn't exist: ${m.path}`,
+            fixable: FIXABLE_CODES.has("missing-file"),
             location: { material_id: m.id, path: m.path },
           });
         }
@@ -134,6 +145,66 @@ export function lintExitCode(summary: { errors: number; warnings: number }): num
   if (summary.errors > 0) return 2;
   if (summary.warnings > 0) return 1;
   return 0;
+}
+
+export interface FixResult {
+  fixed: LintIssue[];
+  remaining: LintIssue[];
+}
+
+// Mechanically repair fixable issues on `draft` in place. Only issues whose
+// code is in FIXABLE_CODES are touched — everything else is returned in
+// `remaining` for the caller to report. Repairs are ordered so that earlier
+// passes can uncover issues the next pass would fix (e.g. shortening an
+// overlong cue may resolve an overlap on the same track).
+export function fixDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS): FixResult {
+  const before = lintDraft(draft, opts);
+  const fixed: LintIssue[] = [];
+
+  // Pass 1: cap over-long cues. Shrinking these first can also close overlaps.
+  for (const track of getTracksByType(draft, "text")) {
+    for (const s of track.segments) {
+      if (s.target_timerange.duration > opts.maxCueDurationUs) {
+        const before = s.target_timerange.duration;
+        s.target_timerange.duration = opts.maxCueDurationUs;
+        if (s.source_timerange && s.source_timerange.duration === before) {
+          s.source_timerange.duration = opts.maxCueDurationUs;
+        }
+      }
+    }
+  }
+
+  // Pass 2: trim overlapping captions so each ends where the next begins.
+  for (const track of getTracksByType(draft, "text")) {
+    const segs = [...track.segments].sort((a, b) => a.target_timerange.start - b.target_timerange.start);
+    for (let i = 0; i < segs.length - 1; i++) {
+      const s = segs[i];
+      const next = segs[i + 1];
+      const end = s.target_timerange.start + s.target_timerange.duration;
+      const overlap = end - next.target_timerange.start;
+      if (overlap > 0) {
+        const newDuration = Math.max(0, s.target_timerange.duration - overlap);
+        const oldDuration = s.target_timerange.duration;
+        s.target_timerange.duration = newDuration;
+        if (s.source_timerange && s.source_timerange.duration === oldDuration) {
+          s.source_timerange.duration = newDuration;
+        }
+      }
+    }
+  }
+
+  const after = lintDraft(draft, opts);
+  const remaining: LintIssue[] = [];
+  const afterKeys = new Set(after.map(issueKey));
+  for (const issue of before) {
+    if (!afterKeys.has(issueKey(issue))) fixed.push(issue);
+  }
+  for (const issue of after) remaining.push(issue);
+  return { fixed, remaining };
+}
+
+function issueKey(i: LintIssue): string {
+  return `${i.code}|${i.location?.segment_id ?? ""}|${i.location?.material_id ?? ""}|${i.location?.path ?? ""}`;
 }
 
 function allSegments(draft: Draft): Array<{ track: Track; segment: Segment }> {

--- a/test/lint.test.mjs
+++ b/test/lint.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { after, describe, it } from "node:test";
 import { spawnCli } from "./helpers/spawn-cli.mjs";
 import { tmpDraft } from "./helpers/tmp-draft.mjs";
@@ -103,6 +103,112 @@ describe("capcut lint", () => {
       const overlaps = r.json.issues.filter((i) => i.code === "caption-overlap");
       assert.ok(overlaps.length > 0, `expected caption-overlap error; got: ${JSON.stringify(r.json.issues)}`);
       assert.equal(r.status, 2);
+    });
+  });
+
+  describe("--fix auto-repair", () => {
+    function seedOverlappingCaptions(draftPath) {
+      const draft = JSON.parse(readFileSync(draftPath, "utf-8"));
+      let mat = draft.materials.texts?.[0];
+      if (!mat) {
+        mat = {
+          id: "fix-mat-1",
+          type: "text",
+          content: '{"text":"Hello","styles":[]}',
+          font_size: 15,
+          text_color: "#FFFFFF",
+          alignment: 1,
+        };
+        draft.materials.texts = [...(draft.materials.texts ?? []), mat];
+      }
+      let textTrack = draft.tracks.find((t) => t.type === "text");
+      if (!textTrack) {
+        textTrack = { id: "fix-text-track", type: "text", name: "captions", attribute: 0, segments: [] };
+        draft.tracks.push(textTrack);
+      }
+      const base = {
+        material_id: mat.id,
+        source_timerange: { start: 0, duration: 1_000_000 },
+        speed: 1,
+        volume: 1,
+        visible: true,
+        clip: { alpha: 1, rotation: 0, scale: { x: 1, y: 1 }, transform: { x: 0, y: 0 } },
+        extra_material_refs: [],
+        render_index: 0,
+      };
+      // Overlap: seg A ends at 2s, seg B starts at 1s (500ms overlap).
+      textTrack.segments.push({
+        ...base,
+        id: "fix-seg-1-aaaa-bbbb-cccc-dddddddddddd",
+        target_timerange: { start: 100_000_000, duration: 2_000_000 },
+      });
+      textTrack.segments.push({
+        ...base,
+        id: "fix-seg-2-aaaa-bbbb-cccc-dddddddddddd",
+        target_timerange: { start: 101_000_000, duration: 2_000_000 },
+      });
+      // A missing-material reference on a separate segment — not fixable.
+      textTrack.segments.push({
+        ...base,
+        id: "fix-seg-3-aaaa-bbbb-cccc-dddddddddddd",
+        material_id: "does-not-exist-in-any-materials",
+        target_timerange: { start: 200_000_000, duration: 1_000_000 },
+      });
+      writeFileSync(draftPath, JSON.stringify(draft));
+    }
+
+    describe("repairs fixable defects and writes atomically", () => {
+      const fix = tmpDraft();
+      after(() => fix.cleanup());
+
+      it("trims overlapping captions, leaves non-fixable issues reported, and writes a .bak", () => {
+        seedOverlappingCaptions(fix.path);
+
+        const r = spawnCli(["lint", fix.path, "--fix", "--no-check-paths"]);
+        assert.ok(r.json, `stdout should be JSON; got: ${r.stdout}`);
+        assert.ok(Array.isArray(r.json.fixed), "expected fixed[] in output");
+        const overlapFixed = r.json.fixed.filter((i) => i.code === "caption-overlap");
+        assert.ok(overlapFixed.length > 0, `expected caption-overlap in fixed; got: ${JSON.stringify(r.json.fixed)}`);
+
+        // The non-fixable missing-material remains and drives exit code 2.
+        const missing = r.json.issues.filter((i) => i.code === "missing-material");
+        assert.ok(missing.length > 0, "missing-material should remain reported");
+        assert.equal(missing[0].fixable, false);
+        assert.equal(r.status, 2);
+
+        // .bak snapshot created by saveDraft.
+        assert.ok(existsSync(`${fix.path}.bak`), "expected .bak to be written next to the draft");
+
+        // The on-disk draft no longer overlaps.
+        const repaired = JSON.parse(readFileSync(fix.path, "utf-8"));
+        const track = repaired.tracks.find((t) => t.segments.some((s) => s.id.startsWith("fix-seg-1")));
+        const segs = [...track.segments].sort((a, b) => a.target_timerange.start - b.target_timerange.start);
+        for (let i = 0; i < segs.length - 1; i++) {
+          const end = segs[i].target_timerange.start + segs[i].target_timerange.duration;
+          assert.ok(end <= segs[i + 1].target_timerange.start, `segments still overlap: ${JSON.stringify(segs)}`);
+        }
+      });
+    });
+
+    describe("--fix --dry-run", () => {
+      const fix = tmpDraft();
+      after(() => fix.cleanup());
+
+      it("previews the plan without writing the draft or a .bak", () => {
+        seedOverlappingCaptions(fix.path);
+        const before = readFileSync(fix.path, "utf-8");
+
+        const r = spawnCli(["lint", fix.path, "--fix", "--dry-run", "--no-check-paths"]);
+        assert.ok(r.json, `stdout should be JSON; got: ${r.stdout}`);
+        // dryRun stamp comes from the shared out() helper.
+        assert.equal(r.json.dryRun, true);
+        const overlapFixed = r.json.fixed.filter((i) => i.code === "caption-overlap");
+        assert.ok(overlapFixed.length > 0, "expected caption-overlap to appear in fixed[] under --dry-run");
+
+        const after = readFileSync(fix.path, "utf-8");
+        assert.equal(after, before, "--dry-run must not modify the draft");
+        assert.ok(!existsSync(`${fix.path}.bak`), "--dry-run must not write a .bak");
+      });
     });
   });
 


### PR DESCRIPTION
Closes #40.

## Summary

Extends `capcut lint` with a `--fix` flag that repairs the schema defects it already detects. Turns lint from a diagnostic into a recovery tool for the common "draft opens corrupted / partially rendered" failure mode.

## Changes

- **`src/lint.ts`**
  - Each `LintIssue` now carries a `fixable: boolean` so callers can tell mechanical repairs from issues that still need human judgement.
  - New `fixDraft(draft, opts)` runs two ordered passes and returns `{ fixed, remaining }`:
    - **`cue-too-long`** — caps caption duration at `--max-cue-secs` (default 7s). Runs first so shortening a cue can also close an overlap.
    - **`caption-overlap`** — trims the earlier caption so it ends exactly where the next begins.
  - `source_timerange.duration` is kept in sync when it matched `target_timerange.duration` (the caption case), so playback still lines up with the shortened cue.
- **`src/index.ts`**
  - Adds the `--fix` flag and wires `cmdLint` to call `fixDraft` when set, then persists via the existing `saveDraft`.
  - Only writes when at least one issue was repaired.
  - Human output prints one `FIXED` line per repair alongside remaining issues plus a `N fixed · errors · warnings · info` summary; JSON output adds a `fixed[]` array.
- **`CHANGELOG.md`** — `## [Unreleased]` entry.

Reuses the existing safety machinery unchanged:

- **Atomic write + `.bak`** — `saveDraft` already writes atomically and drops a `.bak` snapshot.
- **`--dry-run`** — the global flag already gates every `saveDraft`, so `lint --fix --dry-run` previews the plan (`fixed[]` populated, `dryRun: true`) without touching the draft or its `.bak`.
- **`--force-write`** — `saveDraft` already refuses to write while CapCut/JianYing is running unless `--force-write` is passed.

Non-fixable issues (`missing-material`, `missing-file`, `line-too-long`, `caption-gap-too-small`) are left untouched, still reported, and continue to drive the exit code.

## Testing

- Two fixture-backed cases added to `test/lint.test.mjs` covering the two acceptance criteria in the issue:
  1. `--fix` repairs a caption overlap, leaves a `missing-material` error untouched (so exit code stays 2), and writes a `.bak`.
  2. `--fix --dry-run` produces the same `fixed[]` plan but leaves the draft and its `.bak` on disk unchanged.
- Full suite: `220 tests · 216 pass · 4 skipped · 0 fail` (was 218/214/4/0).

