### PR TITLE
fix: resolve CapCut 8.9 template captions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import {
 } from "./decorators.js";
 import { detectEncryption } from "./decrypt.js";
 import { type DoctorCheck, draftDirs, runDoctor } from "./doctor.js";
-import type { Draft, Segment, Track } from "./draft.js";
+import type { Draft, MaterialText, Segment, Track } from "./draft.js";
 import {
   assertTargetsUnchangedOnDisk,
   commitDraftTargets,
@@ -1345,13 +1345,15 @@ function cmdTexts(draft: Draft, flags: Flags): void {
   const textTracks = getTracksByType(draft, "text");
   const data = textTracks.flatMap((track) =>
     track.segments.map((seg) => {
-      const mat = findMaterial(draft.materials.texts, seg.material_id);
+      const resolved = resolveSegmentTextMaterial(draft, seg);
+      const mat = resolved?.material ?? null;
       const t = seg.target_timerange;
       return {
         id: seg.id,
         start_us: t.start,
         duration_us: t.duration,
         text: mat ? extractText(mat.content) : "",
+        ...(resolved?.viaTemplate ? { text_material_id: mat?.id ?? null, template_material_id: seg.material_id } : {}),
       };
     }),
   );
@@ -1371,15 +1373,53 @@ function cmdTexts(draft: Draft, flags: Flags): void {
   }
 }
 
+function resolveSegmentTextMaterial(
+  draft: Draft,
+  seg: Segment,
+): { material: MaterialText; viaTemplate: boolean } | null {
+  const direct = findMaterial(draft.materials.texts, seg.material_id);
+  if (direct) return { material: direct, viaTemplate: false };
+
+  // CapCut 8.9+ caption templates put the segment on a text track but point its
+  // material_id at materials.text_templates[]. The actual editable text lives
+  // behind text_info_resources[].text_material_id in materials.texts[].
+  const templates = draft.materials.text_templates;
+  if (!Array.isArray(templates)) return null;
+  const template = findMaterial(templates as Array<{ id: string }>, seg.material_id) as Record<string, unknown> | null;
+  if (!template) return null;
+  const resources = template.text_info_resources;
+  if (!Array.isArray(resources)) return null;
+  for (const resource of resources) {
+    if (!resource || typeof resource !== "object") continue;
+    const textMaterialId = (resource as Record<string, unknown>).text_material_id;
+    if (typeof textMaterialId !== "string") continue;
+    const nested = findMaterial(draft.materials.texts, textMaterialId);
+    if (nested) return { material: nested, viaTemplate: true };
+  }
+  return null;
+}
+
 function cmdSetText(draft: Draft, filePath: string, segId: string, newText: string, flags: Flags, save = true): void {
   const result = findSegment(draft, segId);
   if (!result) die(`Segment not found: ${segId}`);
-  const mat = findMaterial(draft.materials.texts, result.segment.material_id);
-  if (!mat) die(`Text material not found for segment ${segId}`);
+  const resolved = resolveSegmentTextMaterial(draft, result.segment);
+  const mat = resolved?.material;
+  if (!mat) die(`Text material not found for segment ${segId} (including nested caption-template text)`);
   const oldText = extractText(mat.content);
   mat.content = updateTextContent(mat.content, newText);
+  if (typeof mat.base_content === "string") mat.base_content = updateTextContent(mat.base_content, newText);
+  if (typeof mat.recognize_text === "string") mat.recognize_text = newText;
   if (save) saveDraft(filePath, draft);
-  out({ ok: true, id: result.segment.id, old: oldText, new: newText }, flags);
+  out(
+    {
+      ok: true,
+      id: result.segment.id,
+      old: oldText,
+      new: newText,
+      ...(resolved?.viaTemplate ? { text_material_id: mat.id, template_material_id: result.segment.material_id } : {}),
+    },
+    flags,
+  );
 }
 
 function cmdShift(draft: Draft, filePath: string, segId: string, offsetStr: string, flags: Flags, save = true): void {

--- a/test/edit.test.mjs
+++ b/test/edit.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
 import { after, before, describe, it } from "node:test";
 import { loadDraft } from "./helpers/load-fixture.mjs";
 import { spawnCli } from "./helpers/spawn-cli.mjs";
@@ -34,6 +35,55 @@ describe("capcut set-text", () => {
   it("fails on missing id", () => {
     const r = spawnCli(["set-text", fix.path, "deadbeef", "x"]);
     assert.notEqual(r.status, 0);
+  });
+});
+
+describe("CapCut 8.9 nested caption-template text", () => {
+  const fix = tmpDraft();
+  after(() => fix.cleanup());
+
+  let segmentId;
+  let textMaterialId;
+  before(() => {
+    const draft = loadDraft(fix.path);
+    const track = draft.tracks.find((item) => item.type === "text");
+    const segment = track?.segments?.[0];
+    assert.ok(segment, "fixture needs a text segment");
+    textMaterialId = segment.material_id;
+    segmentId = segment.id;
+    draft.materials.text_templates ??= [];
+    draft.materials.text_templates.push({
+      id: "TEMPLATE-MATERIAL-1",
+      type: "text_template_subtitle",
+      text_info_resources: [{ text_material_id: textMaterialId }],
+    });
+    segment.material_id = "TEMPLATE-MATERIAL-1";
+    writeFileSync(fix.path, `${JSON.stringify(draft, null, 2)}\n`);
+  });
+
+  it("lists text through text_templates.text_info_resources", () => {
+    const r = spawnCli(["texts", fix.path]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const row = r.json.find((item) => item.id === segmentId);
+    assert.ok(row?.text, "nested caption text should not be empty");
+    assert.equal(row.text_material_id, textMaterialId);
+    assert.equal(row.template_material_id, "TEMPLATE-MATERIAL-1");
+  });
+
+  it("set-text updates nested content, base_content, and recognize_text", () => {
+    const r = spawnCli(["set-text", fix.path, segmentId.slice(0, 8), "Corrected contextual caption"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.new, "Corrected contextual caption");
+    assert.equal(r.json.text_material_id, textMaterialId);
+    const draft = loadDraft(fix.path);
+    const material = draft.materials.texts.find((item) => item.id === textMaterialId);
+    assert.equal(JSON.parse(material.content).text, "Corrected contextual caption");
+    if (typeof material.base_content === "string") {
+      assert.equal(JSON.parse(material.base_content).text, "Corrected contextual caption");
+    }
+    if (typeof material.recognize_text === "string") {
+      assert.equal(material.recognize_text, "Corrected contextual caption");
+    }
   });
 });
 


### PR DESCRIPTION
## What
Resolve modern CapCut text-template subtitle segments through text_templates text_info_resources text_material_id before reading or updating materials.texts.

## Why
CapCut 8.9 projects can store subtitle track segment IDs as text-template IDs, causing capcut texts to return blank content and set-text to fail.

## Safety
Direct legacy text lookup remains first. Nested writes update content, base_content, and recognize_text when present.

## Proof
- Full suite: 411 tests, 148 suites, 0 failures
- Added nested template read/write regression tests
- Read-only verified on a real CapCut 8.9 project with 43 template subtitles
