### PR TITLE
Fix CapCut 7.x active timeline writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **CapCut 7.x active Timelines layout** — projects whose `Timelines/project.json` points at `Timelines/<main_timeline_id>/draft_info.json` now read and write that active timeline instead of treating the project-root `draft_info.json` mirror as canonical. Normal edits synchronize every readable mirror through the existing transactional write path, while `sync-timelines` always repairs in the safe active-timeline → root-mirror direction even when the derived mirror has a newer mtime. Legacy root-only projects and explicit file paths retain their existing behavior.
+
 ## [0.16.0] — 2026-07-31
 
 Six features in one release — the next slice of the opportunity backlog, bundled. The headline is version-compat: the draft_info-primary Mac layout becomes first-class instead of edit-only, and masks land in the array variant the installed app build actually reads. Behaviour changes are called out inline; the ones to know: `sync-timelines`/`register` now *work* on Mac-layout projects where they previously refused, `mask` on a version-marked JianYing draft targets the correct variant array (that is the fix), `migrate` also consolidates `common_mask[]`, `lint` probes existing local media by default (`--no-probe` opts out) and gains a warning-severity dangling-ref check — a draft carrying those now exits 1 (run `lint --fix`). Markerless and CapCut drafts write byte-identically to v0.15.0 with no new flags in play.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ English | [中文](./README.zh-CN.md)
 
 **An independent CLI for CapCut / JianYing that any LLM agent can drive — zero dependencies, no server, both namespaces in one binary.**
 
-JSON in, JSON out: every command reads and writes the local draft store directly, with no MCP server or HTTP daemon. On newer CapCut versions it detects and synchronizes every readable timeline target instead of assuming `draft_content.json` is the only source of truth. That gives any model (Claude, DeepSeek, GLM, Kimi) a deterministic boundary for inspection, building, subtitles, captions, translation, and long-form cuts.
+JSON in, JSON out: every command reads and writes the local draft store directly, with no MCP server or HTTP daemon. For CapCut 7.x projects it follows `Timelines/project.json` to the active nested timeline; on newer versions it detects and synchronizes every readable timeline target instead of assuming `draft_content.json` is the only source of truth. That gives any model (Claude, DeepSeek, GLM, Kimi) a deterministic boundary for inspection, building, subtitles, captions, translation, and long-form cuts.
 
 **Use it three ways:**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 
 **任何大模型 Agent 都能驱动的剪映 / CapCut 命令行 —— 零依赖、无服务、CapCut + 剪映共用一个二进制。**
 
-JSON 进、JSON 出：每个命令都直接读写本地草稿存储，不用 MCP 服务或 HTTP 守护进程。新版 CapCut 会自动检测并同步每个可读的时间线目标，不再假设只有 `draft_content.json` 是真源。这给任何模型（Claude、DeepSeek、GLM、Kimi）一个确定性边界，用于查看、构建、字幕、字幕烧录、翻译与长视频切短。
+JSON 进、JSON 出：每个命令都直接读写本地草稿存储，不用 MCP 服务或 HTTP 守护进程。对于 CapCut 7.x 项目，会根据 `Timelines/project.json` 定位活动的嵌套时间线；新版 CapCut 则会自动检测并同步每个可读的时间线目标，不再假设只有 `draft_content.json` 是真源。这给任何模型（Claude、DeepSeek、GLM、Kimi）一个确定性边界，用于查看、构建、字幕、字幕烧录、翻译与长视频切短。
 
 **三种用法：**
 

--- a/docs/command-reference.json
+++ b/docs/command-reference.json
@@ -4246,7 +4246,7 @@
     },
     {
       "name": "sync-timelines",
-      "summary": "Reconcile drifted timeline mirrors (template-2.tmp, draft_info.json) from a read-only draft_content.json (plan with mtimes by default; --apply rewrites only the drifted mirrors).",
+      "summary": "Reconcile drifted mirrors from the layout-selected read-only canonical, including CapCut 7.x's active Timelines draft (plan with mtimes by default; --apply rewrites only drifted mirrors).",
       "usage": "capcut sync-timelines <project-dir> [--apply]",
       "positionals": [
         {
@@ -4263,7 +4263,7 @@
           ],
           "type": "boolean",
           "required": false,
-          "description": "Rewrite only the drifted mirror files from draft_content.json (default: print the plan only)."
+          "description": "Rewrite only drifted mirrors from the layout-selected canonical timeline (default: print the plan only)."
         }
       ],
       "mutates": true,

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -72,7 +72,7 @@
 | `doctor` | `capcut doctor` | no | Environment preflight (Node, whisper, API key, project dir). |
 | `diagnose` | `capcut diagnose <project> [--bundle <report.json>]` | no | Inspect canonical draft files, divergence, and editor-write safety. |
 | `fixture` | `capcut fixture <project> --out <dir>` | no | Build a shareable, redacted compatibility bundle (timeline JSON only) for a version-support issue. |
-| `sync-timelines` | `capcut sync-timelines <project-dir> [--apply]` | yes | Reconcile drifted timeline mirrors (template-2.tmp, draft_info.json) from a read-only draft_content.json (plan with mtimes by default; --apply rewrites only the drifted mirrors). |
+| `sync-timelines` | `capcut sync-timelines <project-dir> [--apply]` | yes | Reconcile drifted mirrors from the layout-selected read-only canonical, including CapCut 7.x's active Timelines draft (plan with mtimes by default; --apply rewrites only drifted mirrors). |
 | `restore` | `capcut restore <project> [--step <number> \| --list]` | yes | Undo writes from .bak / snapshot history (--step N, --list). |
 | `serve` | `capcut serve [--queue <path>] [options]` | no | Run a stateless JSONL job queue from stdin/--queue. |
 | `decrypt` | `capcut decrypt <project-or-file>` | no | Detect JianYing 6.0+ encryption and explain the workaround. |

--- a/src/command-specs.ts
+++ b/src/command-specs.ts
@@ -485,7 +485,7 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
       "apply",
       ["--apply"],
       "boolean",
-      "Rewrite only the drifted mirror files from draft_content.json (default: print the plan only).",
+      "Rewrite only drifted mirrors from the layout-selected canonical timeline (default: print the plan only).",
     ),
   ],
   "replace-media": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,17 +424,18 @@ Maintenance & inspection:
   fixture    <project> --out <dir>              Build a shareable, redacted compatibility bundle
              (timeline JSON only, no media; home paths + emails redacted) to
              attach to a version-support issue like #35.
-  sync-timelines <project-dir> [--apply]        Reconcile timeline mirrors (template-2.tmp,
-             draft_info.json) that drifted from draft_content.json, so a CLI
-             edit is honored by CapCut >= 8.7 (issue #35). Prints the plan
-             (with each file's mtime) by default; --apply rewrites ONLY the
-             drifted mirrors — draft_content.json and in-sync mirrors are
-             never touched — with a .bak per file written. Refuses to write
-             while the editor is running, or when draft_content.json is older
-             than a drifted mirror (the app may have saved newer edits there),
-             unless --force-write. Accepts the project directory or its
-             draft_content.json path. Exits 2 when a mirror exists that the
-             CLI cannot reconcile (binary/encrypted template-2.tmp).
+  sync-timelines <project-dir> [--apply]        Reconcile timeline mirrors from the
+             layout-selected canonical source. CapCut 7.x follows the active
+             Timelines/project.json pointer; newer layouts retain their root
+             draft_content/template selection. Prints the plan (with each
+             file's mtime) by default; --apply rewrites ONLY drifted mirrors —
+             the canonical and in-sync mirrors are never touched — with a .bak
+             per file written. Refuses to write while the editor is running,
+             or when an unpointed canonical is older than a drifted mirror (the
+             app may have saved newer edits there), unless --force-write. Pass
+             the project directory; root draft_content.json and the active 7.x
+             nested draft path are also accepted. Exits 2 when a mirror exists
+             that the CLI cannot reconcile (binary/encrypted template-2.tmp).
 
 Animate:
   keyframe   <project> <id> <property> <time> <value> [--easing <name>]
@@ -3192,11 +3193,12 @@ function cmdRegister(projectPath: string | undefined, flags: Flags): number {
 // `sync-timelines` repairs a draft whose mirror files (template-2.tmp /
 // draft_info.json — including the pre-open mirror's stale GUID) drifted from
 // draft_content.json, the CapCut >= 8.7 "CLI edit silently ignored" failure
-// (issue #35 / #39). draft_content.json is canonical (draft_info.json on the
-// draft_info-primary Mac layout — the plan's canonical_note carries the
-// fixture CTA there) and treated as a read-only source: --apply rewrites EXACTLY the drifted mirrors inside their
-// own envelopes (atomic temp+rename, one .bak per file written) and never
-// touches draft_content.json or in-sync mirrors. Because CapCut >= 8.7 writes
+// (issue #35 / #39), and CapCut 7.x's project-root mirror drift. The storage
+// layout selects a canonical source (including Timelines/<active-id> or the
+// draft_info-primary Mac layout), which remains read-only: --apply rewrites
+// EXACTLY the drifted mirrors inside their own envelopes (atomic temp+rename,
+// one .bak per file written) and never touches the canonical or in-sync mirrors.
+// Because CapCut >= 8.7 writes
 // the mirrors on save, a canonical file OLDER than a drifted mirror may mean
 // the mirror holds newer app edits — --apply refuses that direction unless
 // --force-write. Plan-only by default; --apply writes. Returns the exit code:
@@ -3343,7 +3345,7 @@ function cmdSyncTimelines(projectPath: string | undefined, flags: Flags): number
     },
     flags,
   );
-  if (!flags.quiet) process.stderr.write(`Reconciled from draft_content.json: ${plan.drifted.join(", ")}\n`);
+  if (!flags.quiet) process.stderr.write(`Reconciled from ${plan.canonical}: ${plan.drifted.join(", ")}\n`);
   warnUnreconcilable();
   return ok ? 0 : 2;
 }
@@ -3678,7 +3680,7 @@ const SUMMARIES: Record<string, string> = {
   doctor: "Environment preflight (Node, whisper, API key, project dir).",
   diagnose: "Inspect canonical draft files, divergence, and editor-write safety.",
   "sync-timelines":
-    "Reconcile drifted timeline mirrors (template-2.tmp, draft_info.json) from a read-only draft_content.json (plan with mtimes by default; --apply rewrites only the drifted mirrors).",
+    "Reconcile drifted mirrors from the layout-selected read-only canonical, including CapCut 7.x's active Timelines draft (plan with mtimes by default; --apply rewrites only drifted mirrors).",
   prune: "Remove materials no segment references.",
   register:
     "Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak).",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,13 +1,14 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { platform } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { stripBom } from "./bom.js";
 import type { Draft } from "./draft.js";
 import { assessWriteSafety, atLeast } from "./version.js";
 
 const STANDARD_FILES = ["draft_content.json", "draft_info.json", "draft_meta_info.json", "template-2.tmp"] as const;
+const ACTIVE_TIMELINE_FILES = ["draft_info.json", "draft_content.json"] as const;
 
 export type DraftCandidateName = (typeof STANDARD_FILES)[number] | string;
 
@@ -26,16 +27,17 @@ export interface DraftCandidate {
   error?: string;
 }
 
-/** Which primary project file drives this store: draft_content.json (the
- * layout every pre-Mac-10.x build uses), draft_info.json with no
- * draft_content.json beside it (reported as the primary project file on newer
- * Mac builds — jianying-mcp#5, pyJianYingDraft#177/#194), or neither
- * (timeline readable only from a mirror such as template-2.tmp). */
-export type DraftStoreLayout = "content-primary" | "info-primary" | "unknown";
+/** Which primary project file drives this store: an active draft beneath
+ * Timelines/<main_timeline_id> (CapCut 7.x), root draft_content.json, root
+ * draft_info.json with no draft_content.json beside it (reported on newer Mac
+ * builds — jianying-mcp#5, pyJianYingDraft#177/#194), or neither (timeline
+ * readable only from a mirror such as template-2.tmp). */
+export type DraftStoreLayout = "timelines-primary" | "content-primary" | "info-primary" | "unknown";
 
 export interface DraftStore {
   projectDir: string;
   canonical: DraftCandidate;
+  activeTimeline: DraftCandidate | null;
   targets: DraftCandidate[];
   candidates: DraftCandidate[];
   version: string | null;
@@ -111,8 +113,8 @@ function findTimeline(value: unknown, path: string[] = [], depth = 0): { draft: 
 // Exported for factory.ts (register): read one file into a DraftCandidate —
 // BOM-stripped, envelope-aware — without the sibling discovery a full
 // discoverDraftStore would do.
-export function parseCandidate(path: string): DraftCandidate {
-  const name = path.split(/[\\/]/).pop() ?? path;
+export function parseCandidate(path: string, displayName?: string): DraftCandidate {
+  const name = displayName ?? path.split(/[\\/]/).pop() ?? path;
   if (!existsSync(path)) {
     return {
       name,
@@ -174,22 +176,121 @@ export function parseCandidate(path: string): DraftCandidate {
   }
 }
 
-function candidatePaths(input: string): { projectDir: string; requested: string | null; paths: string[] } {
+interface CandidatePath {
+  path: string;
+  name?: string;
+}
+
+interface CandidatePaths {
+  projectDir: string;
+  requested: string | null;
+  candidates: CandidatePath[];
+  activeTimelinePaths: string[];
+}
+
+function nestedTimelineProjectDir(path: string): string | null {
+  const timelineDir = dirname(path);
+  const timelinesDir = dirname(timelineDir);
+  return basename(timelinesDir).toLowerCase() === "timelines" ? dirname(timelinesDir) : null;
+}
+
+function displayPath(projectDir: string, path: string): string {
+  return relative(projectDir, path).split(sep).join("/");
+}
+
+function isContainedPath(parent: string, child: string): boolean {
+  const path = relative(parent, child);
+  return path.length > 0 && path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+
+function activeTimelineCandidates(projectDir: string): CandidatePath[] {
+  const timelinesDir = resolve(projectDir, "Timelines");
+  const projectJson = join(timelinesDir, "project.json");
+  if (!existsSync(projectJson)) return [];
+
+  let timelineId: unknown;
+  try {
+    const project = JSON.parse(stripBom(readFileSync(projectJson, "utf-8"))) as Record<string, unknown>;
+    timelineId = project.main_timeline_id ?? project.id;
+  } catch {
+    return [];
+  }
+  if (typeof timelineId !== "string" || timelineId.length === 0) return [];
+
+  // project.json is app-authored but still untrusted input. Keep a malformed id
+  // from escaping the project's Timelines directory through `..` or an absolute
+  // path before probing candidate files.
+  const activeDir = resolve(timelinesDir, timelineId);
+  if (!isContainedPath(timelinesDir, activeDir) || !existsSync(activeDir) || !statSync(activeDir).isDirectory()) {
+    return [];
+  }
+
+  let realTimelinesDir: string;
+  try {
+    realTimelinesDir = realpathSync(timelinesDir);
+    if (!isContainedPath(realTimelinesDir, realpathSync(activeDir))) return [];
+  } catch {
+    return [];
+  }
+
+  return ACTIVE_TIMELINE_FILES.flatMap((name) => {
+    const path = join(activeDir, name);
+    if (existsSync(path)) {
+      try {
+        if (!isContainedPath(realTimelinesDir, realpathSync(path))) return [];
+      } catch {
+        return [];
+      }
+    }
+    return [{ path, name: displayPath(projectDir, path) }];
+  });
+}
+
+function candidatePaths(input: string): CandidatePaths {
   const resolved = resolve(input);
   const isFile = existsSync(resolved) && statSync(resolved).isFile();
-  const projectDir = isFile ? dirname(resolved) : resolved;
+  let projectDir = isFile ? dirname(resolved) : resolved;
+  let activeCandidates: CandidatePath[] = [];
+  if (isFile) {
+    const nestedProjectDir = nestedTimelineProjectDir(resolved);
+    if (nestedProjectDir) {
+      const nestedProjectCandidates = activeTimelineCandidates(nestedProjectDir);
+      if (nestedProjectCandidates.some((candidate) => candidate.path === resolved)) {
+        projectDir = nestedProjectDir;
+        activeCandidates = nestedProjectCandidates;
+      }
+    }
+  }
   const requested = isFile ? resolved : null;
-  const paths = requested ? [requested] : [];
+  const candidates: CandidatePath[] = [];
+  const add = (candidate: CandidatePath): void => {
+    const existing = candidates.find((item) => item.path === candidate.path);
+    if (existing) {
+      // Prefer the project-relative label for an active nested timeline over
+      // its otherwise ambiguous basename when the same path was requested.
+      if (candidate.name?.includes("/")) existing.name = candidate.name;
+      return;
+    }
+    candidates.push(candidate);
+  };
+  if (requested) add({ path: requested });
   for (const name of STANDARD_FILES) {
     const path = join(projectDir, name);
-    if (!paths.includes(path)) paths.push(path);
+    add({ path });
   }
-  return { projectDir, requested, paths };
+  if (activeCandidates.length === 0) activeCandidates = activeTimelineCandidates(projectDir);
+  for (const candidate of activeCandidates) add(candidate);
+  return {
+    projectDir,
+    requested,
+    candidates,
+    activeTimelinePaths: activeCandidates.map((candidate) => candidate.path),
+  };
 }
 
 export function discoverDraftStore(input: string): DraftStore {
-  const { projectDir, requested, paths } = candidatePaths(input);
-  const candidates = paths.map(parseCandidate);
+  const { projectDir, requested, candidates: candidateSpecs, activeTimelinePaths } = candidatePaths(input);
+  const candidates = candidateSpecs.map((candidate) => parseCandidate(candidate.path, candidate.name));
   const parseable = candidates.filter((candidate) => candidate.parseable && candidate.draft);
   if (parseable.length === 0) {
     const found = candidates.filter((candidate) => candidate.exists).map((candidate) => candidate.name);
@@ -204,9 +305,28 @@ export function discoverDraftStore(input: string): DraftStore {
     .filter((value): value is string => typeof value === "string" && value.length > 0);
   const version = versions.sort((a, b) => (atLeast(a, b) ? -1 : 1))[0] ?? null;
   const modernStorage = atLeast(version, "8.7");
+  const discoveredActiveTimeline = activeTimelinePaths
+    .map((path) => parseable.find((candidate) => candidate.path === path))
+    .find((candidate): candidate is DraftCandidate => Boolean(candidate));
+  // Preserve the established >=8.7 storage rule: those projects can carry
+  // readable legacy/nested mirrors while template-2.tmp remains app-canonical.
+  // The nested source-of-truth behavior is verified for pre-8.7 CapCut only.
+  const activeTimeline = modernStorage ? undefined : discoveredActiveTimeline;
+  const activeTimelinePathSet = new Set(activeTimelinePaths);
+  const requestedCandidate = requested ? parseable.find((candidate) => candidate.path === requested) : undefined;
+  const explicitlyRequestedActiveTimeline = Boolean(
+    requestedCandidate && activeTimelinePathSet.has(requestedCandidate.path),
+  );
+  const targets = modernStorage
+    ? explicitlyRequestedActiveTimeline
+      ? parseable.filter((candidate) => candidate.path === requested)
+      : parseable.filter((candidate) => !activeTimelinePathSet.has(candidate.path))
+    : requestedCandidate && activeTimelinePathSet.size > 0 && !explicitlyRequestedActiveTimeline
+      ? parseable.filter((candidate) => !activeTimelinePathSet.has(candidate.path))
+      : parseable;
 
-  let canonical: DraftCandidate | undefined;
-  if (requested) canonical = parseable.find((candidate) => candidate.path === requested);
+  let canonical = requestedCandidate;
+  canonical ??= activeTimeline;
   const preference = modernStorage
     ? ["template-2.tmp", "draft_meta_info.json", "draft_content.json", "draft_info.json"]
     : ["draft_content.json", "draft_info.json", "template-2.tmp", "draft_meta_info.json"];
@@ -215,18 +335,25 @@ export function discoverDraftStore(input: string): DraftStore {
     .find((candidate): candidate is DraftCandidate => Boolean(candidate));
   canonical ??= parseable[0];
 
-  const timelineHashes = new Set(parseable.map((candidate) => candidate.timelineHash).filter(Boolean));
+  const timelineHashes = new Set(targets.map((candidate) => candidate.timelineHash).filter(Boolean));
   const contentReadable = parseable.some((candidate) => candidate.name === "draft_content.json");
   const infoReadable = parseable.some((candidate) => candidate.name === "draft_info.json");
   return {
     projectDir,
     canonical,
-    targets: parseable,
+    activeTimeline: activeTimeline ?? null,
+    targets,
     candidates,
     version,
     modernStorage,
     diverged: timelineHashes.size > 1,
-    layout: contentReadable ? "content-primary" : infoReadable ? "info-primary" : "unknown",
+    layout: activeTimeline
+      ? "timelines-primary"
+      : contentReadable
+        ? "content-primary"
+        : infoReadable
+          ? "info-primary"
+          : "unknown",
   };
 }
 
@@ -290,6 +417,14 @@ export function isManagedDraftPath(path: string): boolean {
 // registration metadata, not a mirror, so it is never flagged unreconcilable.
 const MIRROR_FILES = new Set<string>(["draft_info.json", "template-2.tmp"]);
 
+function candidateFileName(candidate: DraftCandidate): string {
+  return basename(candidate.path);
+}
+
+function isNestedTimelineCandidate(candidate: DraftCandidate): boolean {
+  return candidate.name.startsWith("Timelines/");
+}
+
 export interface TimelineSyncTarget {
   file: string;
   state: "canonical" | "in_sync" | "drifted";
@@ -315,8 +450,8 @@ export interface TimelineSyncPlan {
   version: string | null;
   modern_storage: boolean;
   layout: DraftStoreLayout;
-  /** Set when the canonical is not draft_content.json (draft_info-primary
-   * layout): names the promotion and carries the fixture CTA. */
+  /** Set when the canonical is not root draft_content.json: explains which
+   * storage layout selected the canonical source. */
   canonical_note: string | null;
   in_sync: boolean;
   /** Drifted mirrors whose mtime is newer than draft_content.json's. CapCut
@@ -351,53 +486,59 @@ function syncTarget(candidate: DraftCandidate, state: TimelineSyncTarget["state"
 }
 
 /**
- * Plan for `sync-timelines` (issue #39, symptom #35): draft_content.json is
- * canonical (draft_info.json on the draft_info-primary Mac layout — see
- * DraftStoreLayout); every other readable timeline target is compared against
- * it by timeline hash. Direction is always draft_content.json -> mirror, but each
- * target's mtime is surfaced: CapCut >= 8.7 writes the mirrors on save, so a
- * drifted mirror NEWER than draft_content.json may hold app edits that the
+ * Plan for `sync-timelines` (issue #39, symptom #35): the storage layout picks
+ * the authoritative timeline, then every other readable target is compared
+ * against it by timeline hash. CapCut 7.x's Timelines/project.json pointer wins
+ * over project-root mirrors; otherwise root draft_content.json is canonical,
+ * with root draft_info.json promoted for the draft_info-primary Mac layout.
+ * Target mtimes are surfaced because a newer mirror may hold app edits that a
  * repair would roll back (canonical_stale / newer_mirrors flag this; --apply
- * refuses without --force-write). A mirror file that exists but holds no
- * readable timeline (binary/encrypted template-2.tmp) cannot be reconciled
- * and is reported as such instead of being silently skipped. Accepts a
- * project directory or its draft_content.json path; any other explicitly
- * named file is rejected so the plan and the write always cover the same
- * target set.
+ * refuses without --force-write). Timelines/project.json is an explicit source
+ * of authority, so a newer derived root mirror does not reverse that direction.
+ * A mirror file that exists but holds no readable timeline cannot be reconciled
+ * and is reported instead of being silently skipped.
  */
 export function planTimelineSync(input: string): TimelineSyncResult {
   const resolved = resolve(input);
-  if (existsSync(resolved) && statSync(resolved).isFile() && basename(resolved) !== "draft_content.json") {
+  const inputIsFile = existsSync(resolved) && statSync(resolved).isFile();
+  const store = discoverDraftStore(input);
+  const acceptedPrimaryFile =
+    !inputIsFile ||
+    (store.layout === "timelines-primary"
+      ? store.activeTimeline?.path === resolved
+      : basename(resolved) === "draft_content.json");
+  if (!acceptedPrimaryFile) {
     throw new Error(
-      `sync-timelines reconciles a project's mirror files from draft_content.json and cannot target ${basename(resolved)} directly. ` +
+      `sync-timelines reconciles a project's mirror files from its primary timeline and cannot target ${basename(resolved)} directly. ` +
         `Pass the project directory instead: capcut sync-timelines ${dirname(resolved)}`,
     );
   }
-  const store = discoverDraftStore(input);
-  // draft_content.json is the sync canonical. On the draft_info-primary layout
-  // (no draft_content.json; newer Mac builds drive the project from
-  // draft_info.json — jianying-mcp#5, pyJianYingDraft#177/#194) draft_info.json
-  // is promoted to canonical so the repair works there too instead of refusing
-  // (pre-v0.16 behaviour). Round-trip evidence for that layout is
-  // synthetic-only, so the plan carries a canonical_note with the fixture CTA.
+
+  // The active Timelines/<id> draft is authoritative when project.json names
+  // it. Otherwise retain the existing root-primary selection rules.
   const canonical =
+    store.activeTimeline ??
     store.targets.find((candidate) => candidate.name === "draft_content.json") ??
     (store.layout === "info-primary"
       ? store.targets.find((candidate) => candidate.name === "draft_info.json")
       : undefined);
   if (!canonical?.draft) {
     throw new Error(
-      "sync-timelines needs a readable draft_content.json or draft_info.json (the canonical timeline source). " +
+      "sync-timelines needs a readable draft_content.json or draft_info.json, or an active Timelines draft " +
+        "(the canonical timeline source). " +
         "Run `capcut diagnose <project>` to inspect what is on disk.",
     );
   }
   const canonicalNote =
-    canonical.name === "draft_info.json"
-      ? "draft_info.json is the canonical source: this project has no draft_content.json (draft_info-primary " +
-        "layout, reported as the primary project file on newer Mac builds). Round-trip evidence for this layout " +
-        "is synthetic-only — if this project opens fine in your app, contribute a bundle: " +
-        "`capcut fixture <project> --out <dir>`."
-      : null;
+    store.layout === "timelines-primary"
+      ? `${canonical.name} is the canonical source: Timelines/project.json identifies it as the active ` +
+        "CapCut 7.x timeline; project-root timeline files are derived mirrors."
+      : canonical.name === "draft_info.json"
+        ? "draft_info.json is the canonical source: this project has no draft_content.json (draft_info-primary " +
+          "layout, reported as the primary project file on newer Mac builds). Round-trip evidence for this layout " +
+          "is synthetic-only — if this project opens fine in your app, contribute a bundle: " +
+          "`capcut fixture <project> --out <dir>`."
+        : null;
   const canonicalDraft = canonical.draft;
   const canonicalMtime = canonical.mtime ? Date.parse(canonical.mtime) : Number.NaN;
 
@@ -408,8 +549,9 @@ export function planTimelineSync(input: string): TimelineSyncResult {
   const unreconcilable: TimelineSyncUnreconcilable[] = [];
   for (const candidate of store.candidates) {
     if (!candidate.exists || candidate.path === canonical.path) continue;
+    if (store.modernStorage && isNestedTimelineCandidate(candidate)) continue;
     if (!candidate.parseable || !candidate.draft) {
-      if (MIRROR_FILES.has(candidate.name)) {
+      if (MIRROR_FILES.has(candidateFileName(candidate))) {
         unreconcilable.push({
           file: candidate.name,
           reason: candidate.error ?? "no readable timeline",
@@ -426,7 +568,12 @@ export function planTimelineSync(input: string): TimelineSyncResult {
       drifted.push(candidate.name);
       driftedCandidates.push(candidate);
       const mirrorMtime = candidate.mtime ? Date.parse(candidate.mtime) : Number.NaN;
-      if (Number.isFinite(canonicalMtime) && Number.isFinite(mirrorMtime) && mirrorMtime > canonicalMtime) {
+      if (
+        store.layout !== "timelines-primary" &&
+        Number.isFinite(canonicalMtime) &&
+        Number.isFinite(mirrorMtime) &&
+        mirrorMtime > canonicalMtime
+      ) {
         newerMirrors.push(candidate.name);
       }
     }
@@ -484,6 +631,12 @@ export function diagnoseDraftStore(input: string): DraftStoreReport {
         "primary project file on newer Mac builds). Edit commands, register, and sync-timelines treat it as " +
         "canonical, but round-trip evidence for this layout is synthetic-only — if this project opens fine in " +
         "your app, contribute a bundle: `capcut fixture <project> --out <dir>`.",
+    );
+  }
+  if (store.layout === "timelines-primary") {
+    actions.push(
+      `${store.activeTimeline?.name ?? "The active Timelines draft"} is authoritative because ` +
+        "Timelines/project.json selects it. Edit commands synchronize its readable project-root mirrors.",
     );
   }
   if (running.length > 0) actions.push(`Close ${running.join(" / ")} before editing this managed draft.`);

--- a/test/timelines-directory.test.mjs
+++ b/test/timelines-directory.test.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { extractText, findDraft, loadDraft, saveDraft, updateTextContent } from "../dist/draft.js";
+import { diagnoseDraftStore, discoverDraftStore, planTimelineSync } from "../dist/store.js";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+const TIMELINE_ID = "721A7038-E6EE-4D35-AF83-28D787C2C053";
+
+function draftDoc(text, appVersion = "7.7.0") {
+  return {
+    id: "draft-id",
+    name: "capcut-7-project",
+    duration: 1_000_000,
+    fps: 30,
+    canvas_config: { width: 1080, height: 1920, ratio: "9:16" },
+    platform: { app_source: "cc", app_version: appVersion, os: "mac" },
+    tracks: [
+      {
+        id: "track-1",
+        type: "text",
+        name: "text",
+        attribute: 0,
+        segments: [
+          {
+            id: "seg-1",
+            material_id: "mat-1",
+            target_timerange: { start: 0, duration: 1_000_000 },
+            source_timerange: { start: 0, duration: 1_000_000 },
+            speed: 1,
+            volume: 1,
+            visible: true,
+            clip: null,
+            extra_material_refs: [],
+            render_index: 0,
+          },
+        ],
+      },
+    ],
+    materials: {
+      videos: [],
+      audios: [],
+      texts: [
+        {
+          id: "mat-1",
+          type: "text",
+          content: JSON.stringify({ text, styles: [] }),
+          font_size: 15,
+          text_color: "#ffffff",
+          alignment: 1,
+        },
+      ],
+      speeds: [],
+      material_animations: [],
+      audio_fades: [],
+      transitions: [],
+    },
+  };
+}
+
+function draftText(path) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  return extractText(draft.materials.texts[0].content);
+}
+
+function timelineProject(options = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-timelines-"));
+  const timelinesDir = join(dir, "Timelines");
+  const activeDir = join(timelinesDir, TIMELINE_ID);
+  const rootPath = join(dir, "draft_info.json");
+  const nestedName = options.nestedName ?? "draft_info.json";
+  const nestedPath = join(activeDir, nestedName);
+  mkdirSync(activeDir, { recursive: true });
+  writeFileSync(
+    rootPath,
+    JSON.stringify(draftDoc(options.rootText ?? "STALE ROOT MIRROR", options.appVersion), null, 2),
+  );
+  const projectJson = options.projectJson ?? { id: TIMELINE_ID, main_timeline_id: TIMELINE_ID, timelines: [] };
+  writeFileSync(join(timelinesDir, "project.json"), options.projectRaw ?? JSON.stringify(projectJson));
+  if (!options.omitNested) {
+    writeFileSync(
+      nestedPath,
+      JSON.stringify(draftDoc(options.nestedText ?? "REAL TIMELINE SOURCE", options.appVersion), null, 2),
+    );
+  }
+  return {
+    dir,
+    rootPath,
+    nestedPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("CapCut 7.x Timelines directory", () => {
+  it("selects the active nested timeline and labels it distinctly from the root mirror", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+
+    const store = discoverDraftStore(f.dir);
+    assert.equal(store.layout, "timelines-primary");
+    assert.equal(store.canonical.path, f.nestedPath);
+    assert.equal(store.canonical.name, `Timelines/${TIMELINE_ID}/draft_info.json`);
+    assert.equal(store.activeTimeline?.path, f.nestedPath);
+    assert.deepEqual(
+      store.targets.map((candidate) => candidate.name),
+      ["draft_info.json", `Timelines/${TIMELINE_ID}/draft_info.json`],
+    );
+    assert.equal(findDraft(f.dir), f.nestedPath);
+    assert.equal(draftText(loadDraft(f.dir).filePath), "REAL TIMELINE SOURCE");
+
+    const report = diagnoseDraftStore(f.dir);
+    assert.equal(report.layout, "timelines-primary");
+    assert.equal(report.canonical, `Timelines/${TIMELINE_ID}/draft_info.json`);
+    assert.ok(report.next_actions.some((action) => /Timelines\/project\.json/.test(action)));
+  });
+
+  it("uses project.json id when main_timeline_id is absent", () => {
+    const f = timelineProject({ projectJson: { id: TIMELINE_ID } });
+    after(f.cleanup);
+    assert.equal(findDraft(f.dir), f.nestedPath);
+  });
+
+  it("falls back to nested draft_content.json when the active draft_info.json is absent", () => {
+    const f = timelineProject({ nestedName: "draft_content.json" });
+    after(f.cleanup);
+    const store = discoverDraftStore(f.dir);
+    assert.equal(store.canonical.path, f.nestedPath);
+    assert.equal(store.canonical.name, `Timelines/${TIMELINE_ID}/draft_content.json`);
+  });
+
+  it("preserves the established template-2.tmp priority for CapCut 8.7+", () => {
+    const f = timelineProject({ appVersion: "8.7.0" });
+    after(f.cleanup);
+    writeFileSync(
+      join(f.dir, "template-2.tmp"),
+      JSON.stringify({ draft_content: JSON.stringify(draftDoc("MODERN CANONICAL", "8.7.0")) }, null, 2),
+    );
+
+    const store = discoverDraftStore(f.dir);
+    assert.equal(store.modernStorage, true);
+    assert.equal(store.canonical.name, "template-2.tmp");
+    assert.equal(store.activeTimeline, null);
+    assert.equal(extractText(store.canonical.draft.materials.texts[0].content), "MODERN CANONICAL");
+
+    const { draft, filePath } = loadDraft(f.dir);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "MODERN EDIT");
+    saveDraft(filePath, draft);
+    assert.equal(draftText(f.rootPath), "MODERN EDIT");
+    assert.equal(draftText(f.nestedPath), "REAL TIMELINE SOURCE");
+    assert.ok(!existsSync(`${f.nestedPath}.bak`), "unverified modern nested files must remain untouched");
+  });
+
+  it("falls back safely for legacy, unreadable-index, missing-target, and escaping-id projects", () => {
+    const legacyDir = mkdtempSync(join(tmpdir(), "capcut-timelines-legacy-"));
+    after(() => rmSync(legacyDir, { recursive: true, force: true }));
+    const legacyPath = join(legacyDir, "draft_info.json");
+    writeFileSync(legacyPath, JSON.stringify(draftDoc("LEGACY"), null, 2));
+    assert.equal(findDraft(legacyDir), legacyPath);
+
+    const unreadable = timelineProject({ projectRaw: "{ not json" });
+    after(unreadable.cleanup);
+    assert.equal(findDraft(unreadable.dir), unreadable.rootPath);
+
+    const missing = timelineProject({ omitNested: true });
+    after(missing.cleanup);
+    assert.equal(findDraft(missing.dir), missing.rootPath);
+
+    const escaping = timelineProject({ projectJson: { main_timeline_id: "../../outside" }, omitNested: true });
+    after(escaping.cleanup);
+    assert.equal(findDraft(escaping.dir), escaping.rootPath);
+  });
+
+  it("honors explicit root and nested file paths", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+
+    assert.equal(findDraft(f.rootPath), f.rootPath);
+    assert.equal(findDraft(f.nestedPath), f.nestedPath);
+    assert.equal(discoverDraftStore(f.rootPath).canonical.path, f.rootPath);
+    const nestedStore = discoverDraftStore(f.nestedPath);
+    assert.equal(nestedStore.projectDir, f.dir);
+    assert.equal(nestedStore.canonical.path, f.nestedPath);
+    assert.ok(nestedStore.targets.some((candidate) => candidate.path === f.rootPath));
+
+    const { draft, filePath } = loadDraft(f.rootPath);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "EXPLICIT ROOT EDIT");
+    saveDraft(filePath, draft);
+    assert.equal(draftText(f.rootPath), "EXPLICIT ROOT EDIT");
+    assert.equal(draftText(f.nestedPath), "REAL TIMELINE SOURCE");
+    assert.ok(!existsSync(`${f.nestedPath}.bak`), "an explicit root edit must not overwrite the active timeline");
+  });
+
+  it("keeps the active timeline writable when an explicit root file is unreadable", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+    writeFileSync(f.rootPath, "{ not json");
+
+    const store = discoverDraftStore(f.rootPath);
+    assert.equal(store.canonical.path, f.nestedPath);
+    assert.ok(store.targets.some((candidate) => candidate.path === f.nestedPath));
+
+    const { draft, filePath } = loadDraft(f.rootPath);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "NESTED FALLBACK EDIT");
+    saveDraft(filePath, draft);
+    assert.equal(draftText(f.nestedPath), "NESTED FALLBACK EDIT");
+    assert.equal(readFileSync(f.rootPath, "utf-8"), "{ not json");
+  });
+
+  it("keeps an explicitly selected archived timeline isolated from the active project", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+    const archivedDir = join(f.dir, "Timelines", "ARCHIVED-TIMELINE");
+    const archivedPath = join(archivedDir, "draft_info.json");
+    mkdirSync(archivedDir, { recursive: true });
+    writeFileSync(archivedPath, JSON.stringify(draftDoc("ARCHIVED SOURCE"), null, 2));
+
+    const { draft, filePath } = loadDraft(archivedPath);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "ARCHIVED EDIT");
+    saveDraft(filePath, draft);
+
+    assert.equal(draftText(archivedPath), "ARCHIVED EDIT");
+    assert.equal(draftText(f.nestedPath), "REAL TIMELINE SOURCE");
+    assert.equal(draftText(f.rootPath), "STALE ROOT MIRROR");
+  });
+
+  it("rejects a root mirror as an explicit sync source when a nested timeline is authoritative", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+    const rootContent = join(f.dir, "draft_content.json");
+    writeFileSync(rootContent, JSON.stringify(draftDoc("ANOTHER ROOT MIRROR"), null, 2));
+
+    assert.throws(() => planTimelineSync(rootContent), /cannot target draft_content\.json directly/);
+    assert.equal(draftText(f.nestedPath), "REAL TIMELINE SOURCE");
+    assert.equal(draftText(rootContent), "ANOTHER ROOT MIRROR");
+  });
+
+  it("rejects an active-directory symlink that escapes the project", { skip: process.platform === "win32" }, () => {
+    const dir = mkdtempSync(join(tmpdir(), "capcut-timelines-symlink-"));
+    const external = mkdtempSync(join(tmpdir(), "capcut-timelines-external-"));
+    after(() => {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
+    });
+    const timelinesDir = join(dir, "Timelines");
+    const rootPath = join(dir, "draft_info.json");
+    const externalPath = join(external, "draft_info.json");
+    mkdirSync(timelinesDir, { recursive: true });
+    writeFileSync(rootPath, JSON.stringify(draftDoc("SAFE ROOT"), null, 2));
+    writeFileSync(externalPath, JSON.stringify(draftDoc("EXTERNAL FILE"), null, 2));
+    symlinkSync(external, join(timelinesDir, "ESCAPE"), "dir");
+    writeFileSync(join(timelinesDir, "project.json"), JSON.stringify({ id: "ESCAPE", main_timeline_id: "ESCAPE" }));
+
+    assert.equal(findDraft(dir), rootPath);
+    const { draft, filePath } = loadDraft(dir);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "SAFE EDIT");
+    saveDraft(filePath, draft);
+    assert.equal(draftText(rootPath), "SAFE EDIT");
+    assert.equal(draftText(externalPath), "EXTERNAL FILE");
+    assert.ok(!existsSync(`${externalPath}.bak`));
+  });
+
+  it("writes the active timeline and root mirror transactionally, including repeated saves", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+
+    const { draft, filePath } = loadDraft(f.dir);
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "FIRST EDIT");
+    saveDraft(filePath, draft);
+
+    assert.equal(draftText(f.nestedPath), "FIRST EDIT");
+    assert.equal(draftText(f.rootPath), "FIRST EDIT");
+    assert.equal(draftText(`${f.nestedPath}.bak`), "REAL TIMELINE SOURCE");
+    assert.equal(draftText(`${f.rootPath}.bak`), "STALE ROOT MIRROR");
+
+    draft.materials.texts[0].content = updateTextContent(draft.materials.texts[0].content, "SECOND EDIT");
+    saveDraft(filePath, draft);
+    assert.equal(draftText(f.nestedPath), "SECOND EDIT");
+    assert.equal(draftText(f.rootPath), "SECOND EDIT");
+    assert.equal(draftText(`${f.nestedPath}.bak`), "FIRST EDIT");
+    assert.equal(draftText(`${f.rootPath}.bak`), "FIRST EDIT");
+  });
+
+  it("sync-timelines always repairs root mirrors from the selected nested source", () => {
+    const f = timelineProject();
+    after(f.cleanup);
+    const future = new Date(Date.now() + 3_600_000);
+    utimesSync(f.rootPath, future, future);
+
+    const { plan } = planTimelineSync(f.dir);
+    assert.equal(plan.layout, "timelines-primary");
+    assert.equal(plan.canonical, `Timelines/${TIMELINE_ID}/draft_info.json`);
+    assert.deepEqual(plan.drifted, ["draft_info.json"]);
+    assert.equal(plan.canonical_stale, false, "a newer derived mirror must not reverse structural authority");
+    assert.deepEqual(plan.newer_mirrors, []);
+
+    // `--force-write` isolates this direction test from a real/fake CapCut
+    // process elsewhere on the host; the fixture itself is an unmanaged temp dir.
+    const r = spawnCli(["sync-timelines", f.dir, "--apply", "--force-write"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.canonical, `Timelines/${TIMELINE_ID}/draft_info.json`);
+    assert.deepEqual(r.json.reconciled, ["draft_info.json"]);
+    assert.match(r.stderr, new RegExp(`Reconciled from Timelines/${TIMELINE_ID}/draft_info\\.json`));
+    assert.equal(draftText(f.rootPath), "REAL TIMELINE SOURCE");
+    assert.equal(draftText(f.nestedPath), "REAL TIMELINE SOURCE");
+    assert.equal(draftText(`${f.rootPath}.bak`), "STALE ROOT MIRROR");
+    assert.ok(!existsSync(`${f.nestedPath}.bak`), "the canonical nested source must remain read-only");
+  });
+});


### PR DESCRIPTION
## Summary

- follow `Timelines/project.json` to the active nested draft for verified CapCut 7.x projects
- keep the active timeline and readable root mirrors synchronized through the existing transactional write path
- make `sync-timelines` repair in the structurally safe active-timeline → root-mirror direction
- preserve the established CapCut 8.7+ `template-2.tmp` priority and treat legacy nested files as diagnostic-only there
- isolate explicitly addressed root/archived files and reject traversal or symlink escapes
- document the layout-selected canonical behavior in both READMEs, help, changelog, and generated command references

## Root cause

CapCut 7.7 can store the document it actually opens at `Timelines/<main_timeline_id>/draft_info.json`. The project-root `draft_info.json` is a derived mirror. Root-only discovery therefore let commands return success while editing a file that CapCut replaced from the untouched nested timeline on reopen.

## Compatibility and safety

The nested pointer is authoritative only for pre-8.7 CapCut storage. Modern projects retain their existing canonical selection and never write discovered legacy nested files. Explicit non-active file paths remain isolated, unreadable explicit mirrors fall back without dropping the canonical write target, and the active path must remain within the real `Timelines` directory.

## Validation

- Full Node test suite: **531 passed, 0 failed**
- New Timelines regression suite: **12 passed, 0 failed**
- `npm run build`
- `npm run lint`
- `npm run docs:commands`
- `git diff --check`

Closes #50
