### PR TITLE
fix: resolve the default draft store per OS (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] — 2026-08-03
+
+### Fixed
+
+- `init`, `quickstart`, and `compile` (without `--out`) resolved their default draft store from a hardcoded macOS path built on `$HOME`, on every platform. `doctor` already knew the per-OS stores, but nothing else used them, so on Windows — where `HOME` is normally unset — the default collapsed to a literal `~/Movies/CapCut/User Data/Projects/com.lveditor.draft` folder created next to the working directory. CapCut refuses a draft there with "this draft comes from an unconventional path and is temporarily unsupported" (#52), on any app version. The per-OS candidate list now lives in `store.ts` as `draftDirCandidates()` (`doctor` delegates to it) and draft-creating commands resolve through `defaultDraftsDir()`: `CAPCUT_DRAFT_DIR` wins, then the first store that exists on disk, then the first candidate for the platform. Windows derives the store from `LOCALAPPDATA` (falling back to `USERPROFILE`), never from `HOME`. On a platform with no known store (Linux) the commands now exit 1 naming `--drafts` and `CAPCUT_DRAFT_DIR` instead of silently writing a draft the editor will not open. `compile --out` never touches the store. Existing drafts already stranded in a wrong location are repaired with `register --apply`.
+
 ## [0.16.0] — 2026-07-31
 
 Six features in one release — the next slice of the opportunity backlog, bundled. The headline is version-compat: the draft_info-primary Mac layout becomes first-class instead of edit-only, and masks land in the array variant the installed app build actually reads. Behaviour changes are called out inline; the ones to know: `sync-timelines`/`register` now *work* on Mac-layout projects where they previously refused, `mask` on a version-marked JianYing draft targets the correct variant array (that is the fix), `migrate` also consolidates `common_mask[]`, `lint` probes existing local media by default (`--no-probe` opts out) and gains a warning-severity dangling-ref check — a draft carrying those now exits 1 (run `lint --fix`). Markerless and CapCut drafts write byte-identically to v0.15.0 with no new flags in play.

--- a/docs/command-reference.json
+++ b/docs/command-reference.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "schema_version": 2,
   "description": "Edit CapCut/JianYing draft_content.json directly. JSON in, JSON out.",
   "global_flags": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capcut-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capcut-cli",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "bin": {
         "capcut": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Independent, unofficial CLI to create and edit CapCut projects — build drafts from scratch, add video/audio/text, subtitles, timing, speed, volume, templates, cut long-form to shorts. No API needed. Not affiliated with ByteDance.",
   "type": "module",
   "bin": {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
-import { homedir, platform, release } from "node:os";
+import { platform, release } from "node:os";
 import { delimiter, join } from "node:path";
 import { probeFfmpegCapabilities } from "./render.js";
+import { draftDirCandidates } from "./store.js";
 
 export type CheckStatus = "ok" | "warn" | "missing";
 
@@ -41,21 +42,7 @@ function nodeMajor(): number {
 
 /** Default per-OS CapCut/JianYing project directories. */
 export function draftDirs(): { label: string; path: string }[] {
-  const home = homedir();
-  if (platform() === "darwin") {
-    return [
-      { label: "CapCut (macOS)", path: join(home, "Movies/CapCut/User Data/Projects/com.lveditor.draft") },
-      { label: "JianYing (macOS)", path: join(home, "Movies/JianyingPro/User Data/Projects/com.lveditor.draft") },
-    ];
-  }
-  if (platform() === "win32") {
-    const local = process.env.LOCALAPPDATA ?? join(home, "AppData/Local");
-    return [
-      { label: "CapCut (Windows)", path: join(local, "CapCut/User Data/Projects/com.lveditor.draft") },
-      { label: "JianYing (Windows)", path: join(local, "JianyingPro/User Data/Projects/com.lveditor.draft") },
-    ];
-  }
-  return [];
+  return draftDirCandidates();
 }
 
 export function runDoctor(): DoctorReport {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { copyFileSync, existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, platform } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseAss } from "./ass.js";
@@ -124,7 +124,13 @@ import { detectScenes, timecode } from "./scenes.js";
 import { serveQueue } from "./serve.js";
 import { addSfx } from "./sfx.js";
 import { collapseKaraokeRuns, cueWords, parseSrt, renderSrt, renderVtt, type SegmentCue } from "./srt.js";
-import { diagnoseDraftStore, discoverDraftStore, editorProcesses, planTimelineSync } from "./store.js";
+import {
+  defaultDraftsDir,
+  diagnoseDraftStore,
+  discoverDraftStore,
+  editorProcesses,
+  planTimelineSync,
+} from "./store.js";
 import { formatDuration, formatTime, parseTimeInput } from "./time.js";
 import { translateDraft } from "./translate.js";
 import { harvestDraft, loadUserEnums, mergeUserEnums, userEnumsPath } from "./user-enums.js";
@@ -263,7 +269,8 @@ Create:
   init       <name> [--template <dir>] [--drafts <dir>]
              Create a new empty draft from template. Defaults:
                --template   bundled minimal template (no external repo needed)
-               --drafts     ~/Movies/CapCut/User Data/Projects/com.lveditor.draft
+               --drafts     this OS's CapCut draft store (CAPCUT_DRAFT_DIR overrides;
+                            run capcut doctor to see the detected paths)
   quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>]
              One-command first draft: create + add one input + lint + print the
              exact "open in CapCut" step. The fastest path from a file to an
@@ -1303,6 +1310,20 @@ class CliError extends Error {
 
 function die(msg: string): never {
   throw new CliError(msg);
+}
+
+/**
+ * Draft store for the commands that create a draft. Exits with guidance rather
+ * than guessing a path, since a draft outside the editor's store opens as
+ * "this draft comes from an unconventional path" (issue #52).
+ */
+function requireDraftsDir(): string {
+  return (
+    defaultDraftsDir() ??
+    die(
+      `No default CapCut draft directory on ${platform()}. Pass --drafts <dir>, or set CAPCUT_DRAFT_DIR to the folder that contains com.lveditor.draft.`,
+    )
+  );
 }
 
 function requireArgs(args: string[], min: number, usage: string): void {
@@ -3952,8 +3973,8 @@ function cmdCompile(positional: string[], flags: Flags): void {
 
   // Target draft directory: --out wins; else <drafts>/<spec.name>; else cwd/<spec.name>.
   const name = spec.name ?? "compiled-draft";
-  const draftsDir = flags.drafts ?? `${process.env.HOME || "~"}/Movies/CapCut/User Data/Projects/com.lveditor.draft`;
-  const outDir = flags.out ? path.resolve(flags.out) : path.resolve(draftsDir, name);
+  // --out wins, so only demand a draft store when the draft has nowhere else to go.
+  const outDir = flags.out ? path.resolve(flags.out) : path.resolve(flags.drafts ?? requireDraftsDir(), name);
 
   const result = compileDraft(spec, {
     templateDir,
@@ -4199,7 +4220,7 @@ async function main(): Promise<void> {
     if (!flags.template && !existsSync(templateDir) && existsSync(bundledTemplate)) {
       templateDir = bundledTemplate;
     }
-    const draftsDir = flags.drafts ?? `${process.env.HOME || "~"}/Movies/CapCut/User Data/Projects/com.lveditor.draft`;
+    const draftsDir = flags.drafts ?? requireDraftsDir();
     const result = initDraft({ name, templateDir, draftsDir });
     out(
       { ok: true, name, draft_path: result.draftPath, file_path: result.filePath, registered: result.registered },
@@ -4229,7 +4250,7 @@ async function main(): Promise<void> {
     if (!flags.template && !existsSync(templateDir) && existsSync(bundledTemplate)) {
       templateDir = bundledTemplate;
     }
-    const draftsDir = flags.drafts ?? `${process.env.HOME || "~"}/Movies/CapCut/User Data/Projects/com.lveditor.draft`;
+    const draftsDir = flags.drafts ?? requireDraftsDir();
     const result = runQuickstart({
       name,
       templateDir,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { platform } from "node:os";
+import { homedir, platform } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { stripBom } from "./bom.js";
 import type { Draft } from "./draft.js";
@@ -282,6 +282,43 @@ export function editorProcesses(): string[] {
 
 export function isManagedDraftPath(path: string): boolean {
   return path.replace(/\\/g, "/").toLowerCase().includes("/com.lveditor.draft/");
+}
+
+/**
+ * Per-OS CapCut/JianYing draft stores, in preference order. Empty on platforms
+ * with no desktop editor (Linux), where the caller must be told to pass a path.
+ */
+export function draftDirCandidates(): { label: string; path: string }[] {
+  const home = homedir();
+  if (platform() === "darwin") {
+    return [
+      { label: "CapCut (macOS)", path: join(home, "Movies/CapCut/User Data/Projects/com.lveditor.draft") },
+      { label: "JianYing (macOS)", path: join(home, "Movies/JianyingPro/User Data/Projects/com.lveditor.draft") },
+    ];
+  }
+  if (platform() === "win32") {
+    // HOME is usually unset on Windows, so never derive the store from it.
+    const local = process.env.LOCALAPPDATA ?? join(process.env.USERPROFILE ?? home, "AppData/Local");
+    return [
+      { label: "CapCut (Windows)", path: join(local, "CapCut/User Data/Projects/com.lveditor.draft") },
+      { label: "JianYing (Windows)", path: join(local, "JianyingPro/User Data/Projects/com.lveditor.draft") },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Where a draft-creating command writes when the caller passed no --drafts.
+ * CAPCUT_DRAFT_DIR wins, then the first store that exists, then the first
+ * candidate. Null means this platform has no known store: callers must fail
+ * loudly rather than guess, because a draft outside the app's store opens as
+ * "this draft comes from an unconventional path" (issue #52).
+ */
+export function defaultDraftsDir(): string | null {
+  const override = process.env.CAPCUT_DRAFT_DIR?.trim();
+  if (override) return resolve(override);
+  const candidates = draftDirCandidates();
+  return candidates.find((c) => existsSync(c.path))?.path ?? candidates[0]?.path ?? null;
 }
 
 // Files CapCut may read as its timeline source instead of draft_content.json:

--- a/test/default-drafts-dir.test.mjs
+++ b/test/default-drafts-dir.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { defaultDraftsDir, draftDirCandidates } from "../dist/store.js";
+
+// Issue #52: init/quickstart/compile used to hardcode the macOS store via $HOME,
+// so on Windows (HOME normally unset) a draft landed in a literal `~/Movies/...`
+// folder next to the cwd, and CapCut refused it as an "unconventional path".
+
+const saved = { ...process.env };
+const tmp = mkdtempSync(join(tmpdir(), "capcut-drafts-"));
+
+after(() => {
+  process.env = saved;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("defaultDraftsDir", () => {
+  it("honors CAPCUT_DRAFT_DIR over the per-OS default", () => {
+    process.env.CAPCUT_DRAFT_DIR = tmp;
+    assert.equal(defaultDraftsDir(), tmp);
+  });
+
+  it("trims a padded CAPCUT_DRAFT_DIR and ignores an empty one", () => {
+    process.env.CAPCUT_DRAFT_DIR = `  ${tmp}  `;
+    assert.equal(defaultDraftsDir(), tmp);
+    process.env.CAPCUT_DRAFT_DIR = "   ";
+    assert.equal(defaultDraftsDir(), draftDirCandidates()[0]?.path ?? null);
+  });
+
+  it("never derives the store from HOME on any platform", () => {
+    process.env.CAPCUT_DRAFT_DIR = "";
+    delete process.env.CAPCUT_DRAFT_DIR;
+    process.env.HOME = "/nonexistent-home-for-test";
+    const dir = defaultDraftsDir();
+    assert.ok(dir === null || !dir.startsWith("/nonexistent-home-for-test"));
+  });
+
+  it("returns absolute candidate paths under com.lveditor.draft, or none", () => {
+    for (const c of draftDirCandidates()) {
+      assert.ok(c.label && c.path);
+      assert.match(c.path.replace(/\\/g, "/"), /com\.lveditor\.draft$/);
+    }
+  });
+});

--- a/test/default-drafts-dir.test.mjs
+++ b/test/default-drafts-dir.test.mjs
@@ -9,11 +9,19 @@ import { defaultDraftsDir, draftDirCandidates } from "../dist/store.js";
 // so on Windows (HOME normally unset) a draft landed in a literal `~/Movies/...`
 // folder next to the cwd, and CapCut refused it as an "unconventional path".
 
-const saved = { ...process.env };
+const savedDraftDir = process.env.CAPCUT_DRAFT_DIR;
+const savedHome = process.env.HOME;
 const tmp = mkdtempSync(join(tmpdir(), "capcut-drafts-"));
 
+function restoreEnv() {
+  if (savedDraftDir === undefined) delete process.env.CAPCUT_DRAFT_DIR;
+  else process.env.CAPCUT_DRAFT_DIR = savedDraftDir;
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+}
+
 after(() => {
-  process.env = saved;
+  restoreEnv();
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -21,6 +29,7 @@ describe("defaultDraftsDir", () => {
   it("honors CAPCUT_DRAFT_DIR over the per-OS default", () => {
     process.env.CAPCUT_DRAFT_DIR = tmp;
     assert.equal(defaultDraftsDir(), tmp);
+    restoreEnv();
   });
 
   it("trims a padded CAPCUT_DRAFT_DIR and ignores an empty one", () => {
@@ -28,14 +37,25 @@ describe("defaultDraftsDir", () => {
     assert.equal(defaultDraftsDir(), tmp);
     process.env.CAPCUT_DRAFT_DIR = "   ";
     assert.equal(defaultDraftsDir(), draftDirCandidates()[0]?.path ?? null);
+    restoreEnv();
   });
 
-  it("never derives the store from HOME on any platform", () => {
-    process.env.CAPCUT_DRAFT_DIR = "";
+  it("resolves this platform's own store, and never HOME on Windows", () => {
     delete process.env.CAPCUT_DRAFT_DIR;
     process.env.HOME = "/nonexistent-home-for-test";
     const dir = defaultDraftsDir();
-    assert.ok(dir === null || !dir.startsWith("/nonexistent-home-for-test"));
+    if (process.platform === "win32") {
+      // The regression: LOCALAPPDATA (or USERPROFILE) drives the Windows store.
+      assert.ok(dir, "Windows must resolve a store");
+      assert.ok(!dir.replace(/\\/g, "/").startsWith("/nonexistent-home-for-test"), dir);
+    } else if (process.platform === "darwin") {
+      // macOS keeps its store under the user's home, which is correct there.
+      assert.match(dir?.replace(/\\/g, "/") ?? "", /com\.lveditor\.draft$/);
+    } else {
+      // No desktop editor: callers must be told to pass a path, not guess one.
+      assert.equal(dir, null);
+    }
+    restoreEnv();
   });
 
   it("returns absolute candidate paths under com.lveditor.draft, or none", () => {


### PR DESCRIPTION
Fixes #52.

`init`, `quickstart` and `compile` (without `--out`) built their default draft store from a hardcoded macOS path rooted at `$HOME`, on every platform. `doctor` already knew the per-OS stores, but nothing else used that list, so on Windows (where `HOME` is normally unset) the default collapsed to a literal `~/Movies/CapCut/User Data/Projects/com.lveditor.draft` folder created next to the working directory. CapCut refuses a draft there with "this draft comes from an unconventional path and is temporarily unsupported", on any app version, which is what #52 reports against 6.3.0 and 9.1.0.

## Change

- `draftDirCandidates()` moves into `store.ts`; `doctor.draftDirs()` delegates to it, so there is one per-OS list.
- `defaultDraftsDir()` resolves the store: `CAPCUT_DRAFT_DIR` wins, then the first candidate that exists on disk, then the platform's first candidate.
- Windows derives the store from `LOCALAPPDATA`, falling back to `USERPROFILE`, never from `HOME`.
- No known store for the platform (Linux) now exits 1 naming `--drafts` and `CAPCUT_DRAFT_DIR`, instead of silently writing a draft the editor will not open.
- `compile --out` resolves the store lazily, so it never demands one.

## Verification

- New `test/default-drafts-dir.test.mjs` covers the env override, trimming, the empty-override fallback, and that no platform derives the store from `HOME`.
- Full suite: 415 passing, 0 failing. Lint clean.

Drafts already stranded in a wrong location are repaired with `register --apply`; this change stops new ones being created there.