### PR TITLE
fix(fixture): redact device identifiers from shared bundles

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -32,6 +32,19 @@ const REDACTORS: Redactor[] = [
   { kind: "macos_user", pattern: /(\/Users\/)[^/"]+/g, replace: "$1USER" },
   { kind: "linux_user", pattern: /(\/home\/)[^/"]+/g, replace: "$1USER" },
   { kind: "email", pattern: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, replace: "redacted@example.com" },
+  // Device identifiers (#59). CapCut stamps these into the `platform` and
+  // `last_modified_platform` blocks, so they ride along in draft_info.json,
+  // template-2.tmp and every nested timeline copy. Keyed on the field NAME and
+  // never on the value shape: device_id and mac_address are plain 32-hex, and a
+  // bare /[0-9a-f]{32}/ would also blank legitimate material and segment UUIDs.
+  // The optional backslashes match the escaped-quote form that template-2.tmp
+  // uses for its string-JSON. Only a non-empty value matches, so an already
+  // blank hard_disk_id is not counted as something this removed.
+  {
+    kind: "device_ids",
+    pattern: /(\\?"(?:device_id|mac_address|hard_disk_id)\\?"\s*:\s*\\?")[^"\\]+(\\?")/g,
+    replace: "$1$2",
+  },
 ];
 
 export interface SanitizeFileResult {
@@ -323,8 +336,9 @@ mask in the desktop app (two position keyframes are enough), save, and re-run
   return `# Sanitized CapCut draft bundle
 
 This folder was produced by \`capcut fixture\`. It contains **only** the timeline
-JSON files from a real project, with user home paths and email addresses
-redacted. No media from \`assets/\` was copied.
+JSON files from a real project, with user home paths, email addresses and the
+device identifiers CapCut stamps into every draft (\`device_id\`,
+\`mac_address\`, \`hard_disk_id\`) redacted. No media from \`assets/\` was copied.
 
 - Detected app version: ${version ?? "unknown"}
 - Modern storage layout (CapCut >= 8.7): ${modernStorage ? "yes" : "no"}${nestedLine}
@@ -413,10 +427,16 @@ export function sanitizeDraftBundle(input: string, outDir: string): SanitizeRepo
     "utf-8",
   );
 
+  // The report ships inside the bundle, so its own path fields go through the
+  // redactor too (#59). Written raw, they reintroduce the username that every
+  // bundled timeline file just had scrubbed.
+  const { text: safeSourceDir } = redact(store.projectDir, tally);
+  const { text: safeOutDir } = redact(out, tally);
+
   const sanitize: SanitizeReport = {
     ok: true,
-    source_dir: store.projectDir,
-    out_dir: out,
+    source_dir: safeSourceDir,
+    out_dir: safeOutDir,
     version: store.version,
     modern_storage: store.modernStorage,
     files,
@@ -425,7 +445,8 @@ export function sanitizeDraftBundle(input: string, outDir: string): SanitizeRepo
     mask_keyframe_evidence: maskReport.summary,
     notes: [
       "Binary media under assets/ was intentionally excluded — only timeline JSON files are bundled.",
-      "User home paths and email addresses were redacted; review the files before sharing.",
+      "User home paths, email addresses and device identifiers (device_id, mac_address, hard_disk_id) " +
+        "were redacted; review the files before sharing.",
       "Attach this folder to issue #35 (or a new issue) to move the version toward fixture-tested.",
       "mask-keyframe-report.json maps the draft's mask + keyframe structures — the #44 harvest " +
         "(the mask-geometry keyframe encoding has no public ground truth).",

--- a/test/fixture.test.mjs
+++ b/test/fixture.test.mjs
@@ -172,11 +172,27 @@ describe("capcut fixture — mask-keyframe harvest (#44)", () => {
 const DEVICE_ID = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
 const MAC_ADDRESS = "0f1e2d3c4b5a69788796a5b4c3d2e1f0";
 
-// Built under a fake /home/<user>/ prefix so the report's own source_dir has
-// something for the path redactor to catch — a bare tmpdir() path would not.
+// The report's source_dir needs a home-shaped prefix for the path redactor to
+// catch, and the two platforms get there differently.
+//
+// On POSIX we synthesise /home/<user>/ inside the temp dir. On Windows we
+// cannot: the windows_user pattern anchors on the drive letter (`C:\Users\`),
+// so a nested ...\Temp\xxx\Users\someone segment would never match. But
+// tmpdir() there already lives under C:\Users\<real user>\AppData\..., which is
+// exactly the shape the redactor is built for — so Windows asserts against the
+// real account name and ends up testing the production path rather than a
+// synthetic one.
+const WINDOWS = process.platform === "win32";
+
+function homeIdentity(dir) {
+  if (!WINDOWS) return { user: "secretuser", marker: "/home/USER/" };
+  const match = /^[A-Za-z]:[\\/]Users[\\/]([^\\/]+)/.exec(dir);
+  return { user: match ? match[1] : null, marker: "\\Users\\USER" };
+}
+
 function projectWithDeviceIds() {
   const dir = mkdtempSync(join(tmpdir(), "capcut-fixture-dev-"));
-  const projDir = join(dir, "home", "secretuser", "proj");
+  const projDir = WINDOWS ? join(dir, "proj") : join(dir, "home", "secretuser", "proj");
   mkdirSync(projDir, { recursive: true });
   const dst = join(projDir, "draft_content.json");
   copyFileSync(CANONICAL, dst);
@@ -199,7 +215,12 @@ function projectWithDeviceIds() {
     JSON.stringify(JSON.stringify({ platform: { device_id: DEVICE_ID, mac_address: MAC_ADDRESS } })),
     "utf-8",
   );
-  return { projDir, outDir: join(dir, "out"), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  return {
+    projDir,
+    outDir: join(dir, "out"),
+    ...homeIdentity(dir),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
 }
 
 // Walked by hand rather than with recursive readdir: Dirent.parentPath only
@@ -234,7 +255,7 @@ describe("capcut fixture — device identifiers (#59)", () => {
   });
 
   it("leaves no identifier in ANY emitted file, report and README included", (t) => {
-    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    const { projDir, outDir, user, cleanup } = projectWithDeviceIds();
     t.after(cleanup);
 
     const r = spawnCli(["fixture", projDir, "--out", outDir]);
@@ -242,19 +263,21 @@ describe("capcut fixture — device identifiers (#59)", () => {
     for (const { file, text } of allBundledText(outDir)) {
       assert.ok(!text.includes(DEVICE_ID), `${file} leaks device_id`);
       assert.ok(!text.includes(MAC_ADDRESS), `${file} leaks mac_address`);
-      assert.ok(!text.includes("secretuser"), `${file} leaks the username`);
+      if (user) assert.ok(!text.includes(user), `${file} leaks the username`);
     }
   });
 
   it("redacts the report's own source_dir and out_dir", (t) => {
-    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    const { projDir, outDir, user, marker, cleanup } = projectWithDeviceIds();
     t.after(cleanup);
 
     const r = spawnCli(["fixture", projDir, "--out", outDir]);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    assert.ok(!r.json.source_dir.includes("secretuser"), "source_dir must be redacted");
-    assert.ok(r.json.source_dir.includes("/home/USER/"), "source_dir should keep its shape");
-    assert.ok(!r.json.out_dir.includes("secretuser"), "out_dir must be redacted");
+    assert.ok(r.json.source_dir.includes(marker), `source_dir should keep its shape: ${r.json.source_dir}`);
+    if (user) {
+      assert.ok(!r.json.source_dir.includes(user), "source_dir must be redacted");
+      assert.ok(!r.json.out_dir.includes(user), "out_dir must be redacted");
+    }
   });
 
   it("counts what it removed and ignores an already-empty hard_disk_id", (t) => {

--- a/test/fixture.test.mjs
+++ b/test/fixture.test.mjs
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
@@ -153,5 +162,111 @@ describe("capcut fixture — mask-keyframe harvest (#44)", () => {
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
     const after = readFileSync(dst);
     assert.ok(before.equals(after), "fixture must never write to the source draft");
+  });
+});
+
+// #59: `fixture` is documented as producing a shareable bundle and the README
+// invites attaching it to a public issue, so the device identifiers CapCut
+// stamps into every draft must not survive the redactor. The values below are
+// synthetic 32-hex strings shaped like the real ones.
+const DEVICE_ID = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6";
+const MAC_ADDRESS = "0f1e2d3c4b5a69788796a5b4c3d2e1f0";
+
+// Built under a fake /home/<user>/ prefix so the report's own source_dir has
+// something for the path redactor to catch — a bare tmpdir() path would not.
+function projectWithDeviceIds() {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-fixture-dev-"));
+  const projDir = join(dir, "home", "secretuser", "proj");
+  mkdirSync(projDir, { recursive: true });
+  const dst = join(projDir, "draft_content.json");
+  copyFileSync(CANONICAL, dst);
+  const draft = JSON.parse(readFileSync(dst, "utf-8"));
+  const platform = {
+    app_id: 3704,
+    app_version: "8.5.0",
+    device_id: DEVICE_ID,
+    hard_disk_id: "",
+    mac_address: MAC_ADDRESS,
+    os: "mac",
+  };
+  draft.platform = platform;
+  draft.last_modified_platform = { ...platform };
+  writeFileSync(dst, JSON.stringify(draft), "utf-8");
+  // template-2.tmp holds its payload as string-JSON, so the same keys appear
+  // with escaped quotes — the other branch of the redactor's pattern.
+  writeFileSync(
+    join(projDir, "template-2.tmp"),
+    JSON.stringify(JSON.stringify({ platform: { device_id: DEVICE_ID, mac_address: MAC_ADDRESS } })),
+    "utf-8",
+  );
+  return { projDir, outDir: join(dir, "out"), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+// Walked by hand rather than with recursive readdir: Dirent.parentPath only
+// exists from Node 20, and CI still builds on 18.
+function allBundledText(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) allBundledText(p, out);
+    else out.push({ file: p, text: readFileSync(p, "utf-8") });
+  }
+  return out;
+}
+
+describe("capcut fixture — device identifiers (#59)", () => {
+  it("blanks device_id and mac_address in plain and escaped string-JSON alike", (t) => {
+    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    t.after(cleanup);
+
+    const r = spawnCli(["fixture", projDir, "--out", outDir]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    for (const name of ["draft_content.json", "template-2.tmp"]) {
+      const text = readFileSync(join(outDir, name), "utf-8");
+      assert.ok(!text.includes(DEVICE_ID), `${name} must not carry device_id`);
+      assert.ok(!text.includes(MAC_ADDRESS), `${name} must not carry mac_address`);
+    }
+    // The keys survive with empty values — shape is what a fixture is for.
+    const bundled = JSON.parse(readFileSync(join(outDir, "draft_content.json"), "utf-8"));
+    assert.equal(bundled.platform.device_id, "");
+    assert.equal(bundled.platform.mac_address, "");
+    assert.equal(bundled.last_modified_platform.device_id, "");
+    assert.equal(bundled.platform.app_version, "8.5.0", "app_version must be preserved");
+  });
+
+  it("leaves no identifier in ANY emitted file, report and README included", (t) => {
+    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    t.after(cleanup);
+
+    const r = spawnCli(["fixture", projDir, "--out", outDir]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    for (const { file, text } of allBundledText(outDir)) {
+      assert.ok(!text.includes(DEVICE_ID), `${file} leaks device_id`);
+      assert.ok(!text.includes(MAC_ADDRESS), `${file} leaks mac_address`);
+      assert.ok(!text.includes("secretuser"), `${file} leaks the username`);
+    }
+  });
+
+  it("redacts the report's own source_dir and out_dir", (t) => {
+    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    t.after(cleanup);
+
+    const r = spawnCli(["fixture", projDir, "--out", outDir]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.ok(!r.json.source_dir.includes("secretuser"), "source_dir must be redacted");
+    assert.ok(r.json.source_dir.includes("/home/USER/"), "source_dir should keep its shape");
+    assert.ok(!r.json.out_dir.includes("secretuser"), "out_dir must be redacted");
+  });
+
+  it("counts what it removed and ignores an already-empty hard_disk_id", (t) => {
+    const { projDir, outDir, cleanup } = projectWithDeviceIds();
+    t.after(cleanup);
+
+    const r = spawnCli(["fixture", projDir, "--out", outDir]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    // draft_content.json: device_id + mac_address in both platform blocks (4),
+    // template-2.tmp: one of each (2). The blank hard_disk_id contributes none.
+    assert.equal(r.json.redaction_kinds.device_ids, 6, "should count exactly the non-empty identifiers");
+    const content = r.json.files.find((f) => f.file === "draft_content.json");
+    assert.ok(content.redactions >= 4, "per-file totals must include the identifiers");
   });
 });


### PR DESCRIPTION
Closes #59.

`capcut fixture` is documented as producing a shareable bundle and the generated README tells users to attach it to a public issue — but the redactor only handled home paths and emails. `device_id`, `mac_address` and `hard_disk_id` were copied verbatim, so the documented flow published a stable device ID and MAC to a public repo. `SANITIZE_REPORT.json` compounded it by writing `source_dir`/`out_dir` raw, reintroducing the username the timeline files had just had scrubbed.

### Approach

Keyed on the **field name**, not the value shape — `device_id` and `mac_address` are plain 32-hex, so a bare `/[0-9a-f]{32}/` would also blank legitimate material and segment UUIDs. Handles the escaped-quote form `template-2.tmp` uses for its string-JSON. Matches only non-empty values, so an already-blank `hard_disk_id` is not counted as a removal. Keys are preserved with empty values — the on-disk shape is what a fixture is for.

`app_id` is deliberately left alone: it identifies the app, not the machine, and nothing in `src/` reads it. Happy to include it if you'd rather.

### Tests

Four new cases: plain and escaped forms, a sweep asserting no identifier survives in **any** emitted file (report and README included), report path redaction, and an exact redaction count that proves the blank `hard_disk_id` is not over-reported.

651 tests pass, biome clean.

/cc @scornik — this is the fix your 8.5.0 bundle was waiting on.