### PR TITLE
fix(init): warn when the template predates the target store's CapCut

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -4,6 +4,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   statSync,
@@ -16,6 +17,7 @@ import type { Draft, Segment, Timerange, Track } from "./draft.js";
 import { findMaterialGlobal, findSegment, makeTrack, writeAtomic } from "./draft.js";
 import { findEnum, type Namespace } from "./enums.js";
 import { isManagedDraftPath, parseCandidate } from "./store.js";
+import { atLeast, versionTuple } from "./version.js";
 import { fetchWikimediaAsset, isWikimediaUrl, type WikimediaAsset } from "./wikimedia.js";
 
 /**
@@ -114,11 +116,67 @@ export interface InitOptions {
   now?: number; // epoch ms — injectable clock for tests; defaults to Date.now()
 }
 
+/**
+ * Newest `platform.app_version` across the drafts already in a drafts ROOT, or
+ * null when the folder holds no readable draft. store.ts's highestVersion does
+ * the same job across one project's siblings; `init` has no project to discover
+ * yet, so it scans the store instead.
+ */
+export function detectStoreAppVersion(draftsDir: string): string | null {
+  let dirs: string[];
+  try {
+    dirs = readdirSync(draftsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return null; // fresh or unreadable store — nothing to compare against
+  }
+
+  let best: string | null = null;
+  for (const dir of dirs) {
+    for (const name of ["draft_info.json", "draft_content.json"]) {
+      const version = parseCandidate(resolve(draftsDir, dir, name)).draft?.platform?.app_version;
+      if (typeof version !== "string" || version.length === 0) continue;
+      if (best === null || atLeast(version, best)) best = version;
+      break; // one reading per project folder
+    }
+  }
+  return best;
+}
+
+/**
+ * #67: the bundled template declares app_version 6.5.0 and carries none of the
+ * schema markers a modern draft has (`version`, `new_version`, `color_space`).
+ * Dropped into a materially newer store, CapCut lists the draft at 00:00 and
+ * then refuses to open it, blaming the path — which is not the cause, and which
+ * costs the user a long hunt. Name the real reason instead.
+ *
+ * Warn, never refuse: the evidence is a single 8.5.0 report with no committed
+ * fixture, and `--template` is a working escape hatch. Gated on the major
+ * version so a 6.5.0 template stays quiet on a 6.x store.
+ */
+export function templateVersionWarning(templateVersion: string | null, storeVersion: string | null): string | null {
+  if (!templateVersion || !storeVersion) return null;
+  const [templateMajor = 0] = versionTuple(templateVersion);
+  const [storeMajor = 0] = versionTuple(storeVersion);
+  if (storeMajor <= templateMajor) return null;
+  return (
+    `Template declares CapCut ${templateVersion}, but this drafts folder holds projects from ${storeVersion} ` +
+    `(issue #67). CapCut ${storeVersion} may list the new draft with a 00:00 duration and then refuse to open it, ` +
+    `reporting "Current project is from an unusual path and cannot be used currently" — the path is not the cause; ` +
+    `the bundled template predates the schema markers that build writes. Workaround: create an empty project in ` +
+    `CapCut ${storeVersion} and pass its folder with --template <dir>.`
+  );
+}
+
 export function initDraft(opts: InitOptions): { draftPath: string; filePath: string; registered: boolean } {
   const draftPath = resolve(opts.draftsDir, opts.name);
   if (existsSync(draftPath)) {
     throw new Error(`Draft already exists: ${draftPath}. Delete it first or use a different name.`);
   }
+  // Read the store before copying, so the draft being created is not itself
+  // one of the projects the version is derived from.
+  const storeAppVersion = detectStoreAppVersion(opts.draftsDir);
   cpSync(opts.templateDir, draftPath, { recursive: true });
 
   // Find the draft file
@@ -129,6 +187,10 @@ export function initDraft(opts: InitOptions): { draftPath: string; filePath: str
       // Update the draft name + id
       const raw = stripBom(readFileSync(fp, "utf-8"));
       const draft = JSON.parse(raw) as Draft;
+
+      const versionWarning = templateVersionWarning(draft.platform?.app_version ?? null, storeAppVersion);
+      if (versionWarning) process.stderr.write(`WARNING: ${versionWarning}\n`);
+
       draft.name = opts.name;
       const draftId = uuid();
       draft.id = draftId;

--- a/test/create.test.mjs
+++ b/test/create.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
 import { loadDraft, segmentCount } from "./helpers/load-fixture.mjs";
@@ -111,6 +111,87 @@ describe("capcut add-audio", () => {
     const r = spawnCli(["add-audio", fix.path, "/tmp/does-not-exist.mp3", "0s", "5s"]);
     assert.notEqual(r.status, 0);
     assert.match(r.stderr, /not exist|missing|ENOENT/i);
+  });
+});
+
+// #67: the bundled template declares 6.5.0 and omits the schema markers a
+// modern draft carries, so a draft it produces is refused by a much newer
+// CapCut with a misleading "unusual path" error. `init` should name the real
+// cause. Warn, never refuse — --template is a working escape hatch.
+function seedStoreProject(dir, name, appVersion) {
+  const projDir = join(dir, name);
+  mkdirSync(projDir, { recursive: true });
+  // tracks[] + materials{} are what store.ts recognises as a timeline.
+  writeFileSync(
+    join(projDir, "draft_info.json"),
+    JSON.stringify({
+      id: name,
+      name,
+      duration: 0,
+      tracks: [],
+      materials: { videos: [], audios: [], texts: [] },
+      platform: { app_source: "cc", app_version: appVersion },
+    }),
+    "utf-8",
+  );
+}
+
+describe("capcut init — template/store version skew (#67)", () => {
+  it("warns when the store is a major version ahead of the template", () => {
+    const t = tmpDir();
+    try {
+      seedStoreProject(t.dir, "real-8-5-project", "8.5.0");
+      const r = spawnCli(["init", "skewed", "--drafts", t.dir]);
+
+      assert.equal(r.status, 0, "must warn, not refuse");
+      assert.equal(r.json.ok, true);
+      assert.match(r.stderr, /WARNING/);
+      assert.match(r.stderr, /issue #67/);
+      assert.match(r.stderr, /8\.5\.0/, "should name the version actually found in the store");
+      assert.match(r.stderr, /--template/, "should point at the workaround");
+      assert.ok(existsSync(join(t.dir, "skewed", "draft_info.json")), "the draft is still created");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it("stays quiet when the store matches the template's major version", () => {
+    const t = tmpDir();
+    try {
+      seedStoreProject(t.dir, "old-project", "6.9.0");
+      const r = spawnCli(["init", "same-major", "--drafts", t.dir]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.doesNotMatch(r.stderr, /issue #67/);
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it("stays quiet on an empty store, where there is no version to compare", () => {
+    const t = tmpDir();
+    try {
+      const r = spawnCli(["init", "fresh", "--drafts", t.dir]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.doesNotMatch(r.stderr, /issue #67/);
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it("ignores unreadable projects rather than failing the init", () => {
+    const t = tmpDir();
+    try {
+      const junk = join(t.dir, "corrupt-project");
+      mkdirSync(junk, { recursive: true });
+      writeFileSync(join(junk, "draft_info.json"), "{ not json", "utf-8");
+      seedStoreProject(t.dir, "real-9-project", "9.1.0");
+
+      const r = spawnCli(["init", "mixed", "--drafts", t.dir]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.match(r.stderr, /9\.1\.0/, "the readable sibling still sets the store version");
+    } finally {
+      t.cleanup();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #67. Split out of #60 (finding 2), reported by @scornik.

The bundled template declares `app_version 6.5.0` and carries none of the schema markers a modern draft has. Dropped into a materially newer store, CapCut lists the draft at 00:00 and then refuses to open it with "Current project is from an unusual path" — which is wrong about the cause and sends people hunting the path.

`init` now reads the newest `platform.app_version` across the projects already in the drafts folder and warns when the store is a **major version** ahead, naming the real cause and pointing at `--template`.

Two details worth noting:
- the store is read **before** the template is copied, so the draft being created is not one of its own inputs;
- unreadable sibling projects are skipped rather than failing the init.

Warn, never refuse — matching the house rule for report-only evidence. `--template` is a working escape hatch.

Four new tests: skew warns, same-major stays quiet, empty store stays quiet, corrupt sibling is ignored.