### PR TITLE
fix(store): gate the nested-Timelines guidance on detected app version

### DIFF
--- a/src/draft.ts
+++ b/src/draft.ts
@@ -23,7 +23,7 @@ import {
   discoverDraftStore,
   editorProcesses,
   isManagedDraftPath,
-  NESTED_TIMELINES_WRITE_WARNING,
+  nestedTimelinesWriteWarning,
   serializeDraftCandidate,
   storeAfterWrite,
 } from "./store.js";
@@ -397,7 +397,7 @@ export function saveDraft(
   // version guard: restore's mirror re-sync is the escape hatch, not a new
   // sighting of the hazard.
   if (options.skipVersionGuard !== true && store.layout === "timelines-nested") {
-    process.stderr.write(`WARNING: ${NESTED_TIMELINES_WRITE_WARNING}\n`);
+    process.stderr.write(`WARNING: ${nestedTimelinesWriteWarning(store.version)}\n`);
   }
 
   if (!forceWrite) assertTargetsUnchangedOnDisk(store.targets);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,8 @@ import {
   diagnoseDraftStore,
   discoverDraftStore,
   editorProcesses,
-  NESTED_TIMELINES_ACTION,
-  NESTED_TIMELINES_WRITE_WARNING,
+  nestedTimelinesAction,
+  nestedTimelinesWriteWarning,
   planTimelineSync,
 } from "./store.js";
 import { formatDuration, formatTime, parseTimeInput } from "./time.js";
@@ -2939,7 +2939,7 @@ function cmdVersion(draft: Draft, filePath: string, flags: Flags): void {
   // CapCut 7.x nested Timelines/ layout (issue #50): `version` answers "will a
   // write be honored?", and on this layout a root-mirror write may be
   // discarded by the app — name the layout alongside the write-guard notes.
-  if (store.layout === "timelines-nested") v.support.notes.push(NESTED_TIMELINES_ACTION);
+  if (store.layout === "timelines-nested") v.support.notes.push(nestedTimelinesAction(store.version));
   if (flags.human) {
     console.log(`App:          ${v.app}${v.app_source !== "unknown" ? ` (${v.app_source})` : ""}`);
     console.log(`Version:      ${v.app_version ?? "(unknown)"}`);
@@ -3570,7 +3570,8 @@ function cmdSyncTimelines(projectPath: string | undefined, flags: Flags): number
   // discard this repair. Warn on the dry-run preview too, like the version
   // boundary above.
   const warnNestedTimelines = (): void => {
-    if (plan.layout === "timelines-nested") process.stderr.write(`WARNING: ${NESTED_TIMELINES_WRITE_WARNING}\n`);
+    if (plan.layout === "timelines-nested")
+      process.stderr.write(`WARNING: ${nestedTimelinesWriteWarning(plan.version)}\n`);
   };
 
   if (isDryRun()) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -261,6 +261,48 @@ export const NESTED_TIMELINES_ACTION =
   "Evidence for this layout is report-only — if you have such a project, contribute a bundle: " +
   "`capcut fixture <project> --out <dir>`.";
 
+/**
+ * First app version reported to regenerate the nested mirror FROM the root file
+ * rather than the other way round (issue #68).
+ *
+ * #50 reports CapCut 7.x keeping the live document at Timelines/<id>/draft_info.json
+ * and rebuilding the project-root files from it, so a root-mirror edit may be lost.
+ * #68 reports the opposite on 8.5.0: a CLI-written draft with 14 segments was opened
+ * and closed, and afterwards the nested file and the root file were byte-identical
+ * (SHA compared) with every segment intact.
+ *
+ * Both reports stand. The 7.x caution is deliberately NOT softened — the 8.5.0
+ * reporter states they did not test 7.x, which is what #50 actually covers. What was
+ * wrong is that the warning fired on layout alone, so 8.5.0 users saw 7.x text their
+ * own evidence contradicts. An unknown version keeps the cautious wording.
+ */
+const NESTED_MIRROR_FROM_ROOT_SINCE = "8.5.0";
+
+function nestedMirrorIsSafe(appVersion: string | null): boolean {
+  return appVersion !== null && atLeast(appVersion, NESTED_MIRROR_FROM_ROOT_SINCE);
+}
+
+/** Version-gated form of NESTED_TIMELINES_WRITE_WARNING (issue #68). */
+export function nestedTimelinesWriteWarning(appVersion: string | null): string {
+  if (!nestedMirrorIsSafe(appVersion)) return NESTED_TIMELINES_WRITE_WARNING;
+  return (
+    `Nested Timelines/ layout detected on CapCut ${appVersion} (issue #68): on this version the app is reported ` +
+    "to regenerate Timelines/<id>/draft_info.json from the project-root file, so this root-mirror edit should " +
+    "survive the next open. The CLI writes the root files only."
+  );
+}
+
+/** Version-gated form of NESTED_TIMELINES_ACTION (issue #68). */
+export function nestedTimelinesAction(appVersion: string | null): string {
+  if (!nestedMirrorIsSafe(appVersion)) return NESTED_TIMELINES_ACTION;
+  return (
+    `Timelines/ directory with a nested timeline document, on CapCut ${appVersion}: this version is reported to ` +
+    "regenerate the nested document from the project-root file (issue #68 — byte-identical after an open/close " +
+    "round trip), so the root-file writes the edit commands perform are the ones the app keeps. The 7.x caution " +
+    "in issue #50 still applies to older builds."
+  );
+}
+
 function candidatePaths(input: string): { projectDir: string; requested: string | null; paths: string[] } {
   const resolved = resolve(input);
   const isFile = existsSync(resolved) && statSync(resolved).isFile();
@@ -733,7 +775,7 @@ export function diagnoseDraftStore(input: string): DraftStoreReport {
         "your app, contribute a bundle: `capcut fixture <project> --out <dir>`.",
     );
   }
-  if (store.layout === "timelines-nested") actions.push(NESTED_TIMELINES_ACTION);
+  if (store.layout === "timelines-nested") actions.push(nestedTimelinesAction(store.version));
   if (running.length > 0) actions.push(`Close ${running.join(" / ")} before editing this managed draft.`);
   if (actions.length === 0)
     actions.push("Storage targets are readable and agree. A normal CLI write will synchronize them.");

--- a/test/timelines-layout.test.mjs
+++ b/test/timelines-layout.test.mjs
@@ -258,3 +258,52 @@ describe("CapCut 7.x nested Timelines/ layout (issue #50, detection-only guard)"
     );
   });
 });
+
+// #68: the guidance above fired on layout alone, so an 8.5.0 user was shown 7.x
+// text their own evidence contradicts — on that build the nested document was
+// byte-identical to the root file after an open/close round trip. The 7.x
+// caution itself is NOT softened: #50 covers 7.x and the 8.5.0 reporter did not
+// test it. What changes is that the message now depends on detected version.
+describe("nested Timelines/ guidance is version-gated (issue #68)", () => {
+  it("tells an 8.5.0 project the mirror is regenerated from the root file", () => {
+    const f = nestedProject({ appVersion: "8.5.0" });
+    after(f.cleanup);
+
+    const action = diagnoseDraftStore(f.dir).next_actions.find((a) => /Timelines\//.test(a));
+    assert.ok(action, "the layout must still produce a next_action");
+    assert.match(action, /issue #68/);
+    assert.match(action, /regenerate the nested document from the project-root file/);
+    assert.doesNotMatch(action, /may discard those edits/, "the 7.x risk must not be asserted for 8.5.0");
+  });
+
+  it("keeps the cautious #50 wording for 7.x", () => {
+    const f = nestedProject({ appVersion: "7.9.0" });
+    after(f.cleanup);
+
+    const action = diagnoseDraftStore(f.dir).next_actions.find((a) => /Timelines\//.test(a));
+    assert.ok(action, "the layout must still produce a next_action");
+    assert.match(action, /issue #50/);
+    assert.match(action, /may discard those edits/);
+  });
+
+  it("keeps the cautious wording when no version marker is present", () => {
+    const f = nestedProject();
+    after(f.cleanup);
+
+    const action = diagnoseDraftStore(f.dir).next_actions.find((a) => /Timelines\//.test(a));
+    assert.ok(action, "the layout must still produce a next_action");
+    assert.match(action, /issue #50/, "an unknown version stays cautious");
+  });
+
+  it("gates the write-time stderr warning the same way", () => {
+    const f = nestedProject({ appVersion: "8.5.0" });
+    after(f.cleanup);
+    writeFileSync(join(f.dir, "draft_content.json"), JSON.stringify(draftDoc("ROOT CANONICAL", "8.5.0"), null, 2));
+
+    const r = spawnCli(["sync-timelines", f.dir, "--apply", "--force-write"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stderr, /WARNING: Nested Timelines\/ layout detected on CapCut 8\.5\.0/);
+    assert.match(r.stderr, /issue #68/);
+    assert.doesNotMatch(r.stderr, /may\s+be discarded the next time/, "8.5.0 must not get the 7.x risk claim");
+  });
+});


### PR DESCRIPTION
Closes #68. Split out of #60 (finding 1), reported by @scornik.

The nested-layout warning fired on `store.layout` alone while its text is explicitly about **CapCut 7.x** (#50). On 8.5.0 the reporter measured the opposite — after an open/close round trip the nested document and the root file were byte-identical, so the app regenerates the mirror *from* the tool's content.

### Scope note

The 7.x caution is **not** softened. The reporter states plainly they did not test 7.x, which is what #50 actually covers, and an unknown version keeps the cautious wording. The defect was the missing version gate, not the 7.x text.

### Three call sites, not one

Worth flagging for review: `saveDraft` was only one of them. The `version` command's support notes and `sync-timelines` — which rewrites mirrors outside `saveDraft` — each had their own copy. A test that asserted on the write-time stderr is what surfaced the other two.

Four new tests covering 8.5.0, 7.x, unknown version, and the write-time path.