### PR TITLE
docs(draft-schema): record what the mask-keyframe encoding search ruled out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to capcut-cli are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- **The mask-keyframe section records what the encoding search has already ruled out** ([#44](https://github.com/renezander030/capcut-cli/issues/44)). `docs/draft-schema/03-keyframes-and-animations.md` said no capture exists in the neighbouring ecosystem tools without naming what had been checked, so anyone picking the issue up starts that search from zero. It now names the negative result: `pyJianYingDraft`'s `KeyframeProperty` enum — the upstream `src/enums.json` is extracted from — carries the same eleven properties this CLI exposes and nothing for mask geometry, so there is no encoding to borrow and the ground truth has to come from an app-authored capture. No behaviour change; the CLI still declines to write mask keyframes.
+
 ## [0.18.0] — 2026-08-09
 
 Upgrade if you have ever run `capcut fixture`. Bundles produced by earlier versions carry your device identifiers, and the command's documented flow is to attach one to a public issue.

--- a/docs/draft-schema/03-keyframes-and-animations.md
+++ b/docs/draft-schema/03-keyframes-and-animations.md
@@ -164,4 +164,6 @@ The desktop app CAN keyframe mask position/size/rotation/feather in the UI, so a
 
 `capcut-cli` deliberately does not write mask keyframes: an invented encoding would save without error and silently no-op in the app — the pyJianYingDraft#160 failure class, where structures the app ignores produce no diagnostic at all.
 
+**Already ruled out**, so the next person to pick this up does not repeat the search: `pyJianYingDraft`'s `KeyframeProperty` enum — the upstream `src/enums.json` is extracted from — defines eleven properties (position x/y, rotation, scale x/y, uniform scale, alpha, saturation, contrast, brightness, volume) and none that targets mask geometry. That is the same set the table above exposes, so there is no ecosystem encoding to borrow: the ground truth has to come from an app-authored capture.
+
 **How to supply the ground truth:** animate a mask in the desktop app (two position keyframes are enough), save the draft, and run `capcut fixture <project> --out <dir>`. The bundle's `mask-keyframe-report.json` maps every mask material and keyframe structure it finds — unknown `property_type` values, keys on mask entries beyond what the CLI writes, and keyframe-shaped nodes inside mask materials. Attach the bundle to [issue #44](https://github.com/renezander030/capcut-cli/issues/44); it is blocked on exactly this artifact.


### PR DESCRIPTION
## Summary

Records the negative result from searching for the mask-geometry keyframe
encoding, so the next person working on #44 does not repeat it.

The `#44` section of `03-keyframes-and-animations.md` said no capture exists
"in this repo or in the neighbouring ecosystem tools" without naming what had
been checked. That reads as an absence of evidence rather than a search that
was run, so anyone picking the issue up starts it again from zero.

## Changes

- `docs/draft-schema/03-keyframes-and-animations.md` — adds an "already ruled
  out" note: `pyJianYingDraft`'s `KeyframeProperty` enum, the upstream
  `src/enums.json` is extracted from, defines eleven properties (position x/y,
  rotation, scale x/y, uniform scale, alpha, saturation, contrast, brightness,
  volume) and none targeting mask geometry — the same set the property table
  above already exposes. So there is no ecosystem encoding to borrow, and the
  ground truth has to come from an app-authored capture.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Documentation`.

Deliberately scoped to the docs. Both candidate shapes are still unverified, so
this changes no behaviour and the CLI still declines to write mask keyframes.

## Testing

Documentation only — no `src/` or `test/` path is touched, and Biome is scoped
to `src/ test/`. CI runs the full suite on this PR.

Refs #44.
