### PR TITLE
fix(version): withhold release-build guidance from pre-release builds (#102)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@ import { homedir, platform } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { stripBom } from "./bom.js";
 import type { Draft } from "./draft.js";
-import { assessWriteSafety, atLeast } from "./version.js";
+import { assessWriteSafety, atLeast, isPreRelease } from "./version.js";
 
 const STANDARD_FILES = ["draft_content.json", "draft_info.json", "draft_meta_info.json", "template-2.tmp"] as const;
 
@@ -312,12 +312,38 @@ export const NESTED_TIMELINES_MODERN_ACTION =
  */
 const NESTED_MIRROR_FROM_ROOT_SINCE = "8.5.0";
 
+/**
+ * A pre-release at or above the boundary gets neither the 8.5.0 reassurance nor
+ * the 7.x caution: #68's round trip was run on a release build, and the only
+ * >= 8.5 discard report on #50 comes from a pre-release (CapCut 9.2.8-beta4).
+ * Extending a release-build promise across that gap is issue #102.
+ */
 function nestedMirrorIsSafe(appVersion: string | null): boolean {
-  return appVersion !== null && atLeast(appVersion, NESTED_MIRROR_FROM_ROOT_SINCE);
+  return appVersion !== null && !isPreRelease(appVersion) && atLeast(appVersion, NESTED_MIRROR_FROM_ROOT_SINCE);
+}
+
+/** True when the version clears the boundary numerically but is a pre-release,
+ * so the 7.x text would be as wrong for it as the 8.5.0 reassurance (#68, #102). */
+function nestedMirrorIsUnevidencedPreRelease(appVersion: string | null): boolean {
+  return appVersion !== null && isPreRelease(appVersion) && atLeast(appVersion, NESTED_MIRROR_FROM_ROOT_SINCE);
+}
+
+function preReleaseNestedNote(appVersion: string): string {
+  return (
+    `CapCut ${appVersion} is a pre-release build, so neither report on file applies to it (issue #102): the ` +
+    "regenerate-from-root round trip in issue #68 was observed on a release build, and the only discard report " +
+    "above that boundary in issue #50 came from a pre-release (9.2.8-beta4). Edit commands read and write the " +
+    "project-root files only, so treat a root edit as unverified here and check it survives the next open. " +
+    "`capcut sync-timelines <project> --nested --apply` copies the root timeline into the nested documents as an " +
+    "explicit opt-in repair, and `capcut fixture <project> --out <dir>` produces the bundle issue #50 needs."
+  );
 }
 
 /** Version-gated form of NESTED_TIMELINES_WRITE_WARNING (issue #68). */
 export function nestedTimelinesWriteWarning(appVersion: string | null): string {
+  if (nestedMirrorIsUnevidencedPreRelease(appVersion)) {
+    return `Nested Timelines/ layout detected. ${preReleaseNestedNote(appVersion as string)}`;
+  }
   if (!nestedMirrorIsSafe(appVersion)) return NESTED_TIMELINES_WRITE_WARNING;
   return (
     `Nested Timelines/ layout detected on CapCut ${appVersion} (issue #68): on this version the app is reported ` +
@@ -328,6 +354,9 @@ export function nestedTimelinesWriteWarning(appVersion: string | null): string {
 
 /** Version-gated form of NESTED_TIMELINES_ACTION (issue #68). */
 export function nestedTimelinesAction(appVersion: string | null): string {
+  if (nestedMirrorIsUnevidencedPreRelease(appVersion)) {
+    return `Timelines/ directory with a nested timeline document. ${preReleaseNestedNote(appVersion as string)}`;
+  }
   if (!nestedMirrorIsSafe(appVersion)) return NESTED_TIMELINES_ACTION;
   return (
     `Timelines/ directory with a nested timeline document, on CapCut ${appVersion}: this version is reported to ` +

--- a/src/version.ts
+++ b/src/version.ts
@@ -104,6 +104,32 @@ export function atLeast(version: string | null, wanted: string): boolean {
   return true;
 }
 
+/**
+ * Whether a version string carries a pre-release marker — `9.2.8-beta4` and
+ * `8.4.0-beta6` are both real CapCut builds seen on issue #50 — as opposed to a
+ * plain numeric release like `8.5.0`.
+ *
+ * `versionTuple` parses per dot-segment with `parseInt`, so `8.5.0-beta1` yields
+ * `[8, 5, 0]` and compares *equal* to the 8.5.0 release. `atLeast` keeps that
+ * numeric behaviour deliberately: for a hazard gate it is the safe direction, so
+ * a beta still trips a known-broken range instead of slipping under it.
+ *
+ * It is the wrong direction for a gate that *grants* reassurance, which is what
+ * issue #102 is about — a pre-release would inherit an evidence-derived promise
+ * ("the app regenerates the nested document from the root file, so your edit
+ * survives") drawn from a release build it may not resemble. Callers on that
+ * side require a release build via this predicate, so a pre-release resolves
+ * toward caution in both directions rather than only the convenient one.
+ */
+export function isPreRelease(version: string | null): boolean {
+  if (version === null) return false;
+  const trimmed = version.trim();
+  // Anything that does not start with a digit is not a version string we can
+  // reason about; absence of a marker is reported rather than a guess.
+  if (!/^\d/.test(trimmed)) return false;
+  return !/^\d+(?:\.\d+)*$/.test(trimmed);
+}
+
 /** Top-level `version` integer: absent in CLI-created and both committed
  * fixtures, so absence is normal and never penalized. */
 function schemaInt(draft: Draft): number | null {
@@ -251,6 +277,14 @@ export function detectVersion(draft: Draft): VersionInfo {
     support.notes.push(
       "Mask materials are split across variant arrays (`masks`/`common_mask`/`common_masks`) — the app reads only " +
         "one; consolidate with `capcut migrate --from <ver> --to <ver>` (lint reports which arrays are populated)",
+    );
+  }
+  if (isPreRelease(app_version)) {
+    // Surface the marker the version comparison drops, so a bug report carries
+    // the distinction instead of it being flattened before anyone reads it (#102).
+    support.notes.push(
+      `${app_version} is a pre-release build — version comparisons treat it as ${versionTuple(app_version).join(".")}, ` +
+        "and guidance derived from release-build evidence is withheld rather than extended to it",
     );
   }
   if (app_source === "lv" && app_version && !app_version.startsWith("5.9")) {

--- a/test/prerelease-version.test.mjs
+++ b/test/prerelease-version.test.mjs
@@ -1,0 +1,65 @@
+// Issue #102: pre-release markers are dropped by `versionTuple`, so a beta
+// compares equal to its own release. That is safe for a hazard gate and unsafe
+// for a gate that grants reassurance. These tests pin both directions.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nestedTimelinesAction, nestedTimelinesWriteWarning } from "../dist/store.js";
+import { atLeast, isPreRelease, versionTuple } from "../dist/version.js";
+
+test("isPreRelease distinguishes real CapCut build strings", () => {
+  // Both seen on issue #50.
+  assert.equal(isPreRelease("9.2.8-beta4"), true);
+  assert.equal(isPreRelease("8.4.0-beta6"), true);
+  assert.equal(isPreRelease("8.5.0-beta1"), true);
+
+  assert.equal(isPreRelease("8.5.0"), false);
+  assert.equal(isPreRelease("6.5.0"), false);
+  assert.equal(isPreRelease("5.9"), false);
+  assert.equal(isPreRelease(null), false);
+  assert.equal(isPreRelease(""), false);
+  // Not a version string at all — report absence rather than guess.
+  assert.equal(isPreRelease("unknown"), false);
+});
+
+test("atLeast keeps numeric semantics so a pre-release still trips hazard gates", () => {
+  // Deliberate: a 6.0 beta of JianYing is in the encrypted era and must still
+  // match the `>= 6.0 is broken` range rather than slip under it.
+  assert.deepEqual(versionTuple("6.0.0-beta2"), [6, 0, 0]);
+  assert.equal(atLeast("6.0.0-beta2", "6.0"), true);
+  assert.equal(atLeast("9.2.8-beta4", "8.5.0"), true);
+});
+
+test("a pre-release does not inherit the 8.5.0 regenerate-from-root reassurance", () => {
+  const release = nestedTimelinesWriteWarning("8.5.0");
+  assert.match(release, /should survive the next open/);
+
+  const beta = nestedTimelinesWriteWarning("8.5.0-beta1");
+  assert.doesNotMatch(beta, /should survive the next open/);
+  assert.match(beta, /pre-release build/);
+  assert.match(beta, /issue #102/);
+});
+
+test("a pre-release above the boundary is not shown the 7.x text either", () => {
+  // The bug #68 fixed was showing 7.x prose to users whose own version
+  // contradicts it; the pre-release branch must not reintroduce it.
+  const beta = nestedTimelinesWriteWarning("9.2.8-beta4");
+  assert.doesNotMatch(beta, /CapCut 7\.x/);
+  assert.match(beta, /9\.2\.8-beta4/);
+
+  const action = nestedTimelinesAction("9.2.8-beta4");
+  assert.doesNotMatch(action, /CapCut 7\.x is reported/);
+  assert.match(action, /pre-release build/);
+});
+
+test("a pre-release below the boundary keeps the existing cautious text", () => {
+  // 8.4.0-beta6 is under 8.5.0 numerically, so nothing changes for it.
+  const below = nestedTimelinesWriteWarning("8.4.0-beta6");
+  assert.match(below, /issue #50/);
+  assert.doesNotMatch(below, /should survive the next open/);
+});
+
+test("release builds and unknown versions are unchanged", () => {
+  assert.match(nestedTimelinesWriteWarning(null), /CapCut 7\.x/);
+  assert.match(nestedTimelinesAction("8.5.0"), /issue #68/);
+});


### PR DESCRIPTION
Fixes #102.

## The bug

`versionTuple` parses per dot-segment with `parseInt`, so the pre-release marker is dropped:

```
8.5.0-beta1    tuple= [8,5,0]    atLeast("8.5.0")= true
```

A beta therefore inherited the reassurance gated on `NESTED_MIRROR_FROM_ROOT_SINCE`:

> on this version the app is reported to regenerate `Timelines/<id>/draft_info.json` from the project-root file, so this root-mirror edit should survive the next open

That rests on one artifact — the byte-identical open/close round trip on the **8.5.0 release** in #68. Handing it to a beta channel reassures a build the evidence never covered, which is the exact failure mode the boundary exists to prevent.

## The rule this implements

The issue suggested ordering pre-releases below their release globally. That turned out to be wrong in one direction: `atLeast` also gates *hazards*, and there a beta must stay inclusive — a `6.0.0-beta2` JianYing draft has to keep matching the `>= 6.0 is encrypted` broken range instead of slipping under it.

So the rule is **a pre-release resolves toward caution in both directions**:

- `atLeast` keeps its numeric semantics — unchanged, zero blast radius across its nine call sites. Hazard gates still catch betas.
- Gates that *grant* reassurance additionally require a release build, via a new `isPreRelease` predicate.

## Third branch, not a fallback to the 7.x text

A pre-release at or above the boundary gets its own wording rather than dropping through to `NESTED_TIMELINES_WRITE_WARNING`. Showing 7.x prose to a 9.2.8-beta4 user is precisely the bug #68 fixed, and reintroducing it here would trade one wrong message for another. The new text asserts nothing and names both gaps: #68's round trip was a release build, and the only `>= 8.5` discard report on #50 came from a pre-release.

Note the side effect on #50 — k12ktv's 9.2.8-beta4 store now gets cautious wording instead of the survival reassurance. That is the correct outcome: they reported a discard.

## Surfacing

`capcut version` now notes the marker and the tuple it collapses to, so a report carries the distinction instead of it being flattened before anyone reads it. Both current #50 reporters are on betas (9.2.8-beta4, 8.4.0-beta6), and #50 asks k12ktv whether their build was public or beta *because it changes how the registry ceiling should treat it* — a question the code previously could not act on.

## Not in scope

Which file the CLI treats as canonical (#50 / #51) is untouched, and `NESTED_MIRROR_FROM_ROOT_SINCE` itself does not move. This only stops builds the evidence never covered from landing on the reassuring side of the line.

## Tests

`test/prerelease-version.test.mjs` — 6 cases pinning both directions: real CapCut build strings parse correctly, hazard gates stay inclusive, the reassurance is withheld, the 7.x text does not reappear, sub-boundary betas are unaffected, and release/unknown versions are unchanged.

Full suite: 858 pass, 0 fail. `biome check --error-on-warnings` clean.
