### PR TITLE
feat: add capability-free Wasm agent tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,48 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  wasm-component:
+    runs-on: ubuntu-latest
+    name: capability-free Wasm component
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            wasm/capcut-core/package-lock.json
+      - run: npm ci
+      - run: npm --prefix wasm/capcut-core ci
+      - run: npm --prefix wasm/capcut-core audit --audit-level=high
+      - run: npm run wasm:verify
+      - name: Write artifact checksum
+        run: cd dist && sha256sum capcut-core.wasm > capcut-core.wasm.sha256
+        working-directory: wasm/capcut-core
+      - name: Install checksum-pinned Wassette 0.7.0
+        shell: bash
+        run: |
+          curl -fsSLo "$RUNNER_TEMP/wassette.tar.gz" \
+            https://github.com/microsoft/wassette/releases/download/v0.7.0/wassette_0.7.0_linux_amd64.tar.gz
+          echo "c030964b92a1fb9862fc59b8c318099eba501f83a798b822cb9a394fb0f85f20  $RUNNER_TEMP/wassette.tar.gz" \
+            | sha256sum --check --strict
+          mkdir -p "$RUNNER_TEMP/wassette"
+          tar -xzf "$RUNNER_TEMP/wassette.tar.gz" -C "$RUNNER_TEMP/wassette"
+      - name: Exercise all tools through MCP
+        run: npm --prefix wasm/capcut-core run verify:mcp
+        env:
+          WASSETTE_BIN: ${{ runner.temp }}/wassette/wassette
+      - uses: actions/upload-artifact@v4
+        with:
+          name: capcut-core-wasm
+          path: |
+            wasm/capcut-core/dist/capcut-core.wasm
+            wasm/capcut-core/dist/capcut-core.wasm.sha256
+            wasm/capcut-core/THIRD_PARTY_NOTICES.md
+            LICENSE
+          if-no-files-found: error
+
   platform-smoke:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Open the result in CapCut with every track still editable. capcut-cli works dire
 
 [**▶ Watch a captioned output example (60 seconds)**](./media/two-sisters-vietnam-short.mp4)
 
+> [!TIP]
+> **New: an optional Wasm sandbox for agents.** Run `inspect`, `diff`, and `lint-portable` through MCP as an isolated WebAssembly Component. It has zero host imports—no filesystem, network, environment, or process access—and the standard CLI/npm install stays unchanged. [**Build it and inspect the security model →**](https://github.com/renezander030/capcut-cli/tree/master/wasm/capcut-core#readme)
+
 ## Install and open your first editable draft
 
 **Prerequisites:** Node ≥ 18 (built-ins only — no native modules). Optional tools unlock specific commands: Whisper for `caption`, FFmpeg for `render`, ffprobe for automatic media metadata, and `ANTHROPIC_API_KEY` for `translate`.
@@ -49,7 +52,7 @@ Build from source instead: `git clone https://github.com/renezander030/capcut-cl
 
 JSON in, JSON out: every command reads and writes the local draft store directly, with no MCP server or HTTP daemon. On newer CapCut versions it detects and synchronizes every readable timeline target instead of assuming `draft_content.json` is the only source of truth. That gives any model (Claude, DeepSeek, GLM, Kimi) a deterministic boundary for inspection, building, subtitles, captions, translation, and long-form cuts.
 
-**Use it three ways:**
+**Use it four ways:**
 
 - **CLI** — `npm install -g capcut-cli`, then `capcut <command> <project>`
 - **Library** — `import { loadDraft, lintDraft, saveDraft } from "capcut-cli"` (typed, zero-dep)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ JSON in, JSON out: every command reads and writes the local draft store directly
 - **CLI** — `npm install -g capcut-cli`, then `capcut <command> <project>`
 - **Library** — `import { loadDraft, lintDraft, saveDraft } from "capcut-cli"` (typed, zero-dep)
 - **Queue runner** — `capcut serve` reads JSONL jobs from stdin, for [n8n / Make / Coze](./examples/serve-automation.md)
+- **Agent sandbox (experimental)** — build [`capcut-core.wasm`](https://github.com/renezander030/capcut-cli/tree/master/wasm/capcut-core) for three read-only MCP tools with zero filesystem, network, environment, clock, random, stdio, or process imports
+
+### Capability-free Wasm tools for agents
+
+The experimental [`wasm/capcut-core`](https://github.com/renezander030/capcut-cli/tree/master/wasm/capcut-core) source package moves the deterministic, JSON-in/JSON-out boundary into a WebAssembly Component:
+
+- `inspect` matches `capcut info` for valid drafts.
+- `diff` matches `capcut diff` for structural changes.
+- `lint-portable` runs an explicit, parity-tested subset of `capcut lint` that needs no host files or media probing.
+
+The host reads a draft and passes its JSON as tool input. The component itself has no ambient capabilities, and CI proves the built world has zero imports before exercising all three functions through [Wassette](https://github.com/microsoft/wassette) over MCP. From a source checkout, build it with `npm --prefix wasm/capcut-core ci && npm run wasm:verify`; setup and security details are in the [component README](https://github.com/renezander030/capcut-cli/tree/master/wasm/capcut-core#readme).
 
 ## Release notes
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lint:fix": "biome check --write src/ test/",
     "format": "biome format --write src/ test/",
     "docs:commands": "npm run build && node scripts/generate-command-docs.mjs",
+    "wasm:verify": "npm run build && npm --prefix wasm/capcut-core run verify",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/wasm/capcut-core/.gitignore
+++ b/wasm/capcut-core/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+runtime/
+state/
+.cache/

--- a/wasm/capcut-core/README.md
+++ b/wasm/capcut-core/README.md
@@ -1,0 +1,72 @@
+# capcut-core.wasm
+
+An experimental, capability-free WebAssembly Component for read-only CapCut/JianYing draft analysis through agent runtimes such as [Wassette](https://github.com/microsoft/wassette).
+
+It exposes three JSON-in/JSON-out functions:
+
+- `inspect` — parity-tested against `capcut info`.
+- `diff` — parity-tested against `capcut diff`.
+- `lint-portable` — a parity-tested subset of `capcut lint` covering `missing-material`, `dangling-companion-ref`, `cue-too-long`, `caption-too-fast`, `caption-outside-safe-area`, and `caption-overlap`.
+
+The portable lint name is intentional. Full `capcut lint` also checks host files, probes media, reads bundled catalogues, and reasons about store/version metadata. Those checks stay in the Node CLI instead of being silently weakened behind a matching name.
+
+## Security boundary
+
+The host reads `draft_content.json` or `draft_info.json` and passes the content as a string. The component:
+
+- has no filesystem, network, environment, clock, random, stdio, or process imports;
+- cannot discover a draft path or read another file;
+- cannot mutate a project;
+- returns a string result or a string error through its WIT interface.
+
+`npm run verify:component` asks Jco to reconstruct the compiled world and fails unless it contains zero imports and the expected CapCut interface. The MCP integration then asserts that agents see exactly the three declared functions. It starts Wassette with `--disable-builtin-tools`, so component-loading and permission-management tools are absent.
+
+This is a narrower boundary than a container, not a replacement for the full CLI. File discovery, local-path linting, media probing, draft writes, rendering, and network-backed operations remain host responsibilities.
+
+## Build and verify
+
+From the repository root:
+
+```bash
+npm ci
+npm --prefix wasm/capcut-core ci
+npm run wasm:verify
+```
+
+That builds `wasm/capcut-core/dist/capcut-core.wasm`, runs direct contract tests, compares outputs with the current repository CLI, and proves the compiled component has zero imports.
+
+For the raw MCP test, install [Wassette 0.7.0](https://github.com/microsoft/wassette/releases/tag/v0.7.0), then run:
+
+```bash
+WASSETTE_BIN="$(command -v wassette)" npm --prefix wasm/capcut-core run verify:mcp
+```
+
+The test loads the component into an isolated ignored directory, starts stdio MCP with built-ins disabled, calls all three functions, verifies malformed-input recovery, and prints non-gating latency measurements against fresh CLI processes.
+
+## Use with Codex or another MCP client
+
+Build, then load the component into a dedicated Wassette directory:
+
+```bash
+cd wasm/capcut-core
+npm ci
+npm run build
+mkdir -p runtime/components
+wassette component load "file://$PWD/dist/capcut-core.wasm" --component-dir "$PWD/runtime/components"
+```
+
+Register that locked-down runtime with Codex:
+
+```bash
+codex mcp add capcut-core -- wassette run \
+  --component-dir "$PWD/runtime/components" \
+  --disable-builtin-tools
+```
+
+Other MCP clients can use the same `wassette run` command over stdio. Keep the host-side file read visible and explicit—for example, read a draft, then pass its serialized JSON as `draft-json`. Do not grant storage or network permissions: this component declares none and needs none.
+
+## Distribution
+
+Generated `.wasm`, Wassette binaries, component caches, and runtime state are intentionally excluded from Git. CI uploads the platform-neutral component, its SHA-256 checksum, the repository license, and [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) as a build artifact. A future tagged release can publish the same files after the experimental interface stabilizes.
+
+The JavaScript source is MIT-licensed with the repository. The generated artifact embeds Bytecode Alliance runtime code; retain the third-party notices when redistributing it.

--- a/wasm/capcut-core/THIRD_PARTY_NOTICES.md
+++ b/wasm/capcut-core/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third-party notices
+
+The source in this directory is MIT-licensed under the repository's root `LICENSE`.
+
+The generated `capcut-core.wasm` artifact embeds runtime code supplied by the following pinned build dependencies:
+
+- [Bytecode Alliance ComponentizeJS 0.19.3](https://github.com/bytecodealliance/ComponentizeJS), including its SpiderMonkey/StarlingMonkey embedding — Apache License 2.0 with LLVM exceptions; see the upstream [`LICENSE`](https://github.com/bytecodealliance/ComponentizeJS/blob/main/LICENSE).
+- [Bytecode Alliance Jco 1.17.9](https://github.com/bytecodealliance/jco) — Apache License 2.0 with LLVM exception.
+- [Bytecode Alliance Wizer](https://github.com/bytecodealliance/wizer), pulled transitively by ComponentizeJS — Apache License 2.0.
+
+Wassette is used only as an external test/runtime dependency and is not included in the repository or Wasm artifact. Wassette 0.7.0 is MIT-licensed by Microsoft Corporation.
+
+The names WebAssembly, Bytecode Alliance, SpiderMonkey, StarlingMonkey, Wassette, CapCut, JianYing, ByteDance, and their associated marks belong to their respective owners. Inclusion here identifies interoperability and build provenance; it does not imply endorsement.

--- a/wasm/capcut-core/component.js
+++ b/wasm/capcut-core/component.js
@@ -1,0 +1,348 @@
+// Capability-free extraction of capcut-cli's deterministic draft analysis.
+//
+// Deliberately no imports: JSON values are the only input, and the generated
+// Component Model world is built with every ambient capability disabled.
+
+const PORTABLE_CHECKS = [
+  "missing-material",
+  "dangling-companion-ref",
+  "cue-too-long",
+  "caption-too-fast",
+  "caption-outside-safe-area",
+  "caption-overlap",
+];
+
+const DEFAULT_LINT_OPTIONS = {
+  maxCueDurationUs: 7_000_000,
+  maxCharsPerSecond: 20,
+  safeAreaFraction: 0.85,
+};
+
+function parseDraft(json, label) {
+  let draft;
+  try {
+    draft = JSON.parse(json);
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!draft || typeof draft !== "object") throw new Error(`${label} must be a JSON object`);
+  if (!Array.isArray(draft.tracks)) throw new Error(`${label}.tracks must be an array`);
+  if (!draft.materials || typeof draft.materials !== "object") {
+    throw new Error(`${label}.materials must be an object`);
+  }
+  return draft;
+}
+
+function ok(value) {
+  return JSON.stringify(value);
+}
+
+function fail(error) {
+  // ComponentizeJS maps a thrown string to WIT result.err. Throwing an Error
+  // object crosses the generated ABI less predictably across toolchain builds.
+  throw (error instanceof Error ? error.message : String(error));
+}
+
+function getMaterialTypes(draft) {
+  return Object.entries(draft.materials)
+    .filter(([, value]) => Array.isArray(value))
+    .map(([type, items]) => ({ type, count: items.length }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function inspect(draftJson) {
+  try {
+    const draft = parseDraft(draftJson, "draft-json");
+    const totalSegments = draft.tracks.reduce(
+      (count, track) => count + (Array.isArray(track.segments) ? track.segments.length : 0),
+      0,
+    );
+    const materialTypes = getMaterialTypes(draft);
+    const materialTypesWithItems = materialTypes.filter((material) => material.count > 0);
+    const canvas = draft.canvas_config ?? {};
+    return ok({
+      id: draft.id,
+      name: draft.name || draft.id,
+      duration_us: draft.duration,
+      fps: draft.fps,
+      width: canvas.width,
+      height: canvas.height,
+      ratio: canvas.ratio,
+      tracks: draft.tracks.length,
+      segments: totalSegments,
+      platform: draft.platform
+        ? `${draft.platform.app_source === "cc" ? "CapCut" : "JianYing"} ${draft.platform.app_version}`
+        : null,
+      material_types: materialTypes.length,
+      materials_with_items: materialTypesWithItems.length,
+      material_summary: materialTypesWithItems.map((material) => ({
+        type: material.type,
+        count: material.count,
+      })),
+    });
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+function extractText(content) {
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed.text) return parsed.text;
+  } catch {
+    return String(content ?? "")
+      .replace(/<[^>]*>/g, "")
+      .replace(/\[|\]/g, "")
+      .trim();
+  }
+  return content;
+}
+
+function findMaterial(items, id) {
+  return (items ?? []).find((material) => material.id === id);
+}
+
+function materialIds(draft) {
+  const ids = new Set();
+  for (const items of Object.values(draft.materials)) {
+    if (!Array.isArray(items)) continue;
+    for (const material of items) {
+      if (material && typeof material === "object" && typeof material.id === "string") ids.add(material.id);
+    }
+  }
+  return ids;
+}
+
+function shortId(id) {
+  return String(id).slice(0, 8);
+}
+
+function lintPortableIssues(draft) {
+  const issues = [];
+  const knownMaterialIds = materialIds(draft);
+
+  for (const track of draft.tracks) {
+    for (const segment of track.segments ?? []) {
+      if (!segment.material_id || knownMaterialIds.has(segment.material_id)) continue;
+      issues.push({
+        severity: "error",
+        code: "missing-material",
+        message: `Segment ${shortId(segment.id)} references material ${shortId(segment.material_id)} that does not exist in any materials.*`,
+        fixable: false,
+        suggested_command: `capcut remove <project> ${shortId(segment.id)}`,
+        location: {
+          track: track.name,
+          segment_id: segment.id,
+          material_id: segment.material_id,
+        },
+      });
+    }
+  }
+
+  for (const track of draft.tracks) {
+    for (const segment of track.segments ?? []) {
+      for (const reference of segment.extra_material_refs ?? []) {
+        if (typeof reference !== "string" || reference === "" || knownMaterialIds.has(reference)) continue;
+        issues.push({
+          severity: "warning",
+          code: "dangling-companion-ref",
+          message: `Segment ${shortId(segment.id)} carries companion ref ${shortId(reference)} in extra_material_refs that resolves to no material — the app's behaviour on it is undefined`,
+          fixable: true,
+          location: {
+            track: track.name,
+            segment_id: segment.id,
+            material_id: reference,
+          },
+        });
+      }
+    }
+  }
+
+  for (const track of draft.tracks.filter((candidate) => candidate.type === "text")) {
+    const segments = [...(track.segments ?? [])].sort(
+      (a, b) => a.target_timerange.start - b.target_timerange.start,
+    );
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      const material = findMaterial(draft.materials.texts, segment.material_id);
+      const text = material ? extractText(material.content) : "";
+
+      if (segment.target_timerange.duration > DEFAULT_LINT_OPTIONS.maxCueDurationUs) {
+        issues.push({
+          severity: "warning",
+          code: "cue-too-long",
+          message: `Caption ${shortId(segment.id)} runs ${Math.round(segment.target_timerange.duration / 1000)}ms (>${DEFAULT_LINT_OPTIONS.maxCueDurationUs / 1_000_000}s)`,
+          fixable: true,
+          location: { track: track.name, segment_id: segment.id },
+        });
+      }
+
+      if (String(text).length > 0 && segment.target_timerange.duration > 0) {
+        const visibleCharacters = String(text).replace(/\s+/g, "").length;
+        const seconds = segment.target_timerange.duration / 1_000_000;
+        const charactersPerSecond = visibleCharacters / seconds;
+        if (visibleCharacters > 0 && charactersPerSecond > DEFAULT_LINT_OPTIONS.maxCharsPerSecond) {
+          const neededMilliseconds = Math.ceil(
+            (visibleCharacters / DEFAULT_LINT_OPTIONS.maxCharsPerSecond) * 1000,
+          );
+          issues.push({
+            severity: "warning",
+            code: "caption-too-fast",
+            message: `Caption ${shortId(segment.id)} runs at ${charactersPerSecond.toFixed(1)} chars/s (>${DEFAULT_LINT_OPTIONS.maxCharsPerSecond}) — ${visibleCharacters} characters in ${Math.round(seconds * 1000)}ms`,
+            fixable: false,
+            suggested_command: `capcut trim <project> ${segment.id} <start> ${neededMilliseconds}ms  # or shorten the text`,
+            location: { track: track.name, segment_id: segment.id },
+          });
+        }
+      }
+
+      const canvas = draft.canvas_config;
+      const y = segment.clip?.transform?.y;
+      if (
+        canvas &&
+        typeof canvas.width === "number" &&
+        typeof canvas.height === "number" &&
+        canvas.height > canvas.width &&
+        typeof y === "number" &&
+        Math.abs(y) > DEFAULT_LINT_OPTIONS.safeAreaFraction
+      ) {
+        issues.push({
+          severity: "warning",
+          code: "caption-outside-safe-area",
+          message: `Caption ${shortId(segment.id)} sits at y=${y.toFixed(2)} on a ${canvas.width}x${canvas.height} vertical canvas (|y|>${DEFAULT_LINT_OPTIONS.safeAreaFraction}) — inside the band TikTok/Reels/Shorts overlay with their own UI`,
+          fixable: false,
+          suggested_command: `capcut text-style <project> ${segment.id} --y ${(
+            Math.sign(y) * DEFAULT_LINT_OPTIONS.safeAreaFraction
+          ).toFixed(2)}`,
+          location: { track: track.name, segment_id: segment.id },
+        });
+      }
+
+      const next = segments[index + 1];
+      if (next) {
+        const end = segment.target_timerange.start + segment.target_timerange.duration;
+        const gap = next.target_timerange.start - end;
+        if (gap < 0) {
+          issues.push({
+            severity: "error",
+            code: "caption-overlap",
+            message: `Captions ${shortId(segment.id)} and ${shortId(next.id)} overlap by ${Math.round(-gap / 1000)}ms on track "${track.name}"`,
+            fixable: true,
+            location: { track: track.name, segment_id: segment.id },
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function summarize(issues) {
+  const summary = { errors: 0, warnings: 0, info: 0, total: issues.length };
+  for (const issue of issues) {
+    if (issue.severity === "error") summary.errors += 1;
+    else if (issue.severity === "warning") summary.warnings += 1;
+    else summary.info += 1;
+  }
+  return summary;
+}
+
+function lintPortable(draftJson) {
+  try {
+    const draft = parseDraft(draftJson, "draft-json");
+    const issues = lintPortableIssues(draft);
+    const summary = summarize(issues);
+    return ok({
+      ok: summary.errors === 0,
+      scope: "portable-subset",
+      checks: PORTABLE_CHECKS,
+      summary,
+      issues,
+    });
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+function indexSegments(draft) {
+  const index = new Map();
+  for (const track of draft.tracks) {
+    for (const segment of track.segments ?? []) index.set(segment.id, segment);
+  }
+  return index;
+}
+
+function indexMaterialContent(draft) {
+  const index = new Map();
+  for (const items of Object.values(draft.materials)) {
+    if (!Array.isArray(items)) continue;
+    for (const material of items) {
+      if (typeof material?.id === "string") index.set(material.id, JSON.stringify(material));
+    }
+  }
+  return index;
+}
+
+function diff(beforeJson, afterJson) {
+  try {
+    const before = parseDraft(beforeJson, "before-json");
+    const after = parseDraft(afterJson, "after-json");
+    const beforeSegments = indexSegments(before);
+    const afterSegments = indexSegments(after);
+    const segmentAdded = [];
+    const segmentRemoved = [];
+    const segmentChanged = [];
+
+    for (const [id, segment] of afterSegments) {
+      if (!beforeSegments.has(id)) {
+        segmentAdded.push(id);
+        continue;
+      }
+      const previous = beforeSegments.get(id);
+      const fields = [];
+      if (previous.target_timerange.start !== segment.target_timerange.start) fields.push("start");
+      if (previous.target_timerange.duration !== segment.target_timerange.duration) fields.push("duration");
+      if (previous.material_id !== segment.material_id) fields.push("material_id");
+      if (JSON.stringify(previous.content ?? null) !== JSON.stringify(segment.content ?? null)) fields.push("content");
+      if (previous.speed !== segment.speed) fields.push("speed");
+      if (previous.volume !== segment.volume) fields.push("volume");
+      if (fields.length > 0) segmentChanged.push({ id, fields });
+    }
+    for (const id of beforeSegments.keys()) {
+      if (!afterSegments.has(id)) segmentRemoved.push(id);
+    }
+
+    const beforeMaterials = indexMaterialContent(before);
+    const afterMaterials = indexMaterialContent(after);
+    const materialAdded = [...afterMaterials.keys()].filter((id) => !beforeMaterials.has(id));
+    const materialRemoved = [...beforeMaterials.keys()].filter((id) => !afterMaterials.has(id));
+    const materialChanged = [...afterMaterials.keys()].filter(
+      (id) => beforeMaterials.has(id) && beforeMaterials.get(id) !== afterMaterials.get(id),
+    );
+    const changed =
+      segmentAdded.length +
+        segmentRemoved.length +
+        segmentChanged.length +
+        materialAdded.length +
+        materialRemoved.length +
+        materialChanged.length >
+      0;
+
+    return ok({
+      ok: true,
+      changed,
+      tracks: { a: before.tracks.length, b: after.tracks.length },
+      segments: { added: segmentAdded, removed: segmentRemoved, changed: segmentChanged },
+      materials: { added: materialAdded, removed: materialRemoved, changed: materialChanged },
+    });
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+export const capcutCore = { inspect, lintPortable, diff };
+
+// ComponentizeJS ignores exports that are absent from the WIT world. Keeping
+// direct access here makes deterministic contract tests fast and readable.
+export const __test = { inspect, lintPortable, diff, lintPortableIssues, summarize };

--- a/wasm/capcut-core/package-lock.json
+++ b/wasm/capcut-core/package-lock.json
@@ -1,0 +1,998 @@
+{
+  "name": "@capcut-cli/capcut-core-wasm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@capcut-cli/capcut-core-wasm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@bytecodealliance/componentize-js": "0.19.3",
+        "@bytecodealliance/jco": "1.17.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bytecodealliance/componentize-js": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.19.3.tgz",
+      "integrity": "sha512-ju7Y4WeF0B9uMkSPHJgmT6ouEfSwbe9M1uR/YOnYZjBpxJjH9qzxIkJg/kf8NycVDyFJ2/lscmJ1E1uPiDQVRQ==",
+      "dev": true,
+      "workspaces": [
+        "."
+      ],
+      "dependencies": {
+        "@bytecodealliance/jco": "^1.15.1",
+        "@bytecodealliance/wizer": "^10.0.0",
+        "es-module-lexer": "^1.6.0",
+        "oxc-parser": "^0.76.0"
+      },
+      "bin": {
+        "componentize-js": "src/cli.js"
+      }
+    },
+    "node_modules/@bytecodealliance/jco": {
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.17.9.tgz",
+      "integrity": "sha512-HvDSdbxlSbazIwH0lV5BO/KqOeX3HN0oocauyDWIMnSFTJhl0OCZIbocvMVAvHIJvTimxo+ge6NRM+v5plMhIA==",
+      "dev": true,
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.19.3",
+        "@bytecodealliance/preview2-shim": "^0.17.9",
+        "binaryen": "^123.0.0",
+        "commander": "^14",
+        "mkdirp": "^3",
+        "ora": "^8",
+        "terser": "^5"
+      },
+      "bin": {
+        "jco": "src/jco.js"
+      }
+    },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.9.tgz",
+      "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
+      "dev": true,
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/wizer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-10.0.0.tgz",
+      "integrity": "sha512-ziWmovyu1jQl9TsKlfC2bwuUZwxVPFHlX4fOqTzxhgS76jITIo45nzODEwPgU+jjmOr8F3YX2V2wAChC5NKujg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wizer": "wizer.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@bytecodealliance/wizer-darwin-arm64": "10.0.0",
+        "@bytecodealliance/wizer-darwin-x64": "10.0.0",
+        "@bytecodealliance/wizer-linux-arm64": "10.0.0",
+        "@bytecodealliance/wizer-linux-s390x": "10.0.0",
+        "@bytecodealliance/wizer-linux-x64": "10.0.0",
+        "@bytecodealliance/wizer-win32-x64": "10.0.0"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-10.0.0.tgz",
+      "integrity": "sha512-dhZTWel+xccGTKSJtI9A7oM4yyP20FWflsT+AoqkOqkCY7kCNrj4tmMtZ6GXZFRDkrPY5+EnOh62sfShEibAMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-10.0.0.tgz",
+      "integrity": "sha512-r/LUIZw6Q3Hf4htd46mD+EBxfwjBkxVIrTM1r+B2pTCddoBYQnKVdVsI4UFyy7NoBxzEg8F8BwmTNoSLmFRjpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-arm64/-/wizer-linux-arm64-10.0.0.tgz",
+      "integrity": "sha512-pGSfFWXzeTqHm6z1PtVaEn+7Fm3QGC8YnHrzBV4sQDVS3N1NwmuHZAc8kslmlFPNdu61ycEvdOsSgCny8JPQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-s390x": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-s390x/-/wizer-linux-s390x-10.0.0.tgz",
+      "integrity": "sha512-O8vHxRTAdb1lUnVXMIMTcp/9q4pq1D4iIKigJCipg2JN15taV9uFAWh0fO88wylXwuSlO7dOE1AwQl54fMKXQg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-s390x": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-10.0.0.tgz",
+      "integrity": "sha512-fJtM1sy43FBMnp+xpapFX6U1YdTBKA/1T4CYfG/qeE8jn0SXk2EuiYoY/EnC2uyNy9hjTrvfdYO5n4MXW0EIdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-win32-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-10.0.0.tgz",
+      "integrity": "sha512-55BPLfGT7iT7gH5M69NpTM16QknJZ7OxJ0z73VOEoeGA9CT8QPKMRzFKsPIvLs+W8G28fdudFA94nElrdkp3Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.76.0.tgz",
+      "integrity": "sha512-1XJW/16CDmF5bHE7LAyPPmEEVnxSadDgdJz+xiLqBrmC4lfAeuAfRw3HlOygcPGr+AJsbD4Z5sFJMkwjbSZlQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.76.0.tgz",
+      "integrity": "sha512-yoQwSom8xsB+JdGsPUU0xxmxLKiF2kdlrK7I56WtGKZilixuBf/TmOwNYJYLRWkBoW5l2/pDZOhBm2luwmLiLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.76.0.tgz",
+      "integrity": "sha512-uRIopPLvr3pf2Xj7f5LKyCuqzIU6zOS+zEIR8UDYhcgJyZHnvBkfrYnfcztyIcrGdQehrFUi3uplmI09E7RdiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.76.0.tgz",
+      "integrity": "sha512-a0EOFvnOd2FqmDSvH6uWLROSlU6KV/JDKbsYDA/zRLyKcG6HCsmFnPsp8iV7/xr9WMbNgyJi6R5IMpePQlUq7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.76.0.tgz",
+      "integrity": "sha512-ikRYDHL3fOdZwfJKmcdqjlLgkeNZ3Ez0qM8wAev5zlHZ+lY/Ig7qG5SCqPlvuTu+nNQ6zrFFaKvvt69EBKXU/g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.76.0.tgz",
+      "integrity": "sha512-dtRv5J5MRCLR7x39K8ufIIW4svIc7gYFUaI0YFXmmeOBhK/K2t/CkguPnDroKtsmXIPHDRtmJ1JJYzNcgJl6Wg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.76.0.tgz",
+      "integrity": "sha512-IE4iiiggFH2snagQxHrY5bv6dDpRMMat+vdlMN/ibonA65eOmRLp8VLTXnDiNrcla/itJ1L9qGABHNKU+SnE8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.76.0.tgz",
+      "integrity": "sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.76.0.tgz",
+      "integrity": "sha512-0tqqu1pqPee2lLGY8vtYlX1L415fFn89e0a3yp4q5N9f03j1rRs0R31qesTm3bt/UK8HYjECZ+56FCVPs2MEMQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.76.0.tgz",
+      "integrity": "sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.76.0.tgz",
+      "integrity": "sha512-7/acaG9htovp3gp/J0kHgbItQTuHctl+rbqPPqZ9DRBYTz8iV8kv3QN8t8Or8i/hOmOjfZp9McDoSU1duoR4/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.76.0.tgz",
+      "integrity": "sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.76.0.tgz",
+      "integrity": "sha512-wHdkHdhf6AWBoO8vs5cpoR6zEFY1rB+fXWtq6j/xb9j/lu1evlujRVMkh8IM/M/pOUIrNkna3nzST/mRImiveQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.76.0.tgz",
+      "integrity": "sha512-G7ZlEWcb2hNwCK3qalzqJoyB6HaTigQ/GEa7CU8sAJ/WwMdG/NnPqiC9IqpEAEy1ARSo4XMALfKbKNuqbSs5mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.76.0.tgz",
+      "integrity": "sha512-0jLzzmnu8/mqNhKBnNS2lFUbPEzRdj5ReiZwHGHpjma0+ullmmwP2AqSEqx3ssHDK9CpcEMdKOK2LsbCfhHKIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.76.0.tgz",
+      "integrity": "sha512-CH3THIrSViKal8yV/Wh3FK0pFhp40nzW1MUDCik9fNuid2D/7JJXKJnfFOAvMxInGXDlvmgT6ACAzrl47TqzkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "123.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-123.0.0.tgz",
+      "integrity": "sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-as": "bin/wasm-as",
+        "wasm-ctor-eval": "bin/wasm-ctor-eval",
+        "wasm-dis": "bin/wasm-dis",
+        "wasm-merge": "bin/wasm-merge",
+        "wasm-metadce": "bin/wasm-metadce",
+        "wasm-opt": "bin/wasm-opt",
+        "wasm-reduce": "bin/wasm-reduce",
+        "wasm-shell": "bin/wasm-shell",
+        "wasm2js": "bin/wasm2js"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.76.0.tgz",
+      "integrity": "sha512-l98B2e9evuhES7zN99rb1QGhbzx25829TJFaKi2j0ib3/K/G5z1FdGYz6HZkrU3U8jdH7v2FC8mX1j2l9JrOUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.76.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm64": "0.76.0",
+        "@oxc-parser/binding-darwin-arm64": "0.76.0",
+        "@oxc-parser/binding-darwin-x64": "0.76.0",
+        "@oxc-parser/binding-freebsd-x64": "0.76.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.76.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.76.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.76.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.76.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.76.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.76.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.76.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.76.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    }
+  }
+}

--- a/wasm/capcut-core/package.json
+++ b/wasm/capcut-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@capcut-cli/capcut-core-wasm",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Capability-free WebAssembly Component for deterministic CapCut draft inspection",
+  "type": "module",
+  "scripts": {
+    "build": "node -e \"require('node:fs').mkdirSync('dist',{recursive:true})\" && jco componentize ./component.js --wit ./wit --disable all -o ./dist/capcut-core.wasm",
+    "test": "node --test test/*.test.mjs",
+    "verify:component": "node scripts/verify-component.mjs",
+    "verify:mcp": "node scripts/mcp-e2e.mjs",
+    "verify": "npm run build && npm test && npm run verify:component"
+  },
+  "devDependencies": {
+    "@bytecodealliance/componentize-js": "0.19.3",
+    "@bytecodealliance/jco": "1.17.9"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/wasm/capcut-core/scripts/mcp-e2e.mjs
+++ b/wasm/capcut-core/scripts/mcp-e2e.mjs
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { __test } from "../component.js";
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const repositoryRoot = resolve(packageDirectory, "../..");
+const fixturePath = resolve(repositoryRoot, "test/draft_content.json");
+const cliPath = resolve(repositoryRoot, "dist/index.js");
+const artifactPath = join(packageDirectory, "dist/capcut-core.wasm");
+const wassette = process.env.WASSETTE_BIN ?? "wassette";
+const runId = `${process.pid}-${Date.now()}`;
+const componentDirectory = join(packageDirectory, "runtime", runId, "components");
+const xdgRoot = join(packageDirectory, "runtime", runId, "xdg");
+mkdirSync(componentDirectory, { recursive: true });
+mkdirSync(xdgRoot, { recursive: true });
+
+const fixtureJson = readFileSync(fixturePath, "utf8");
+const changed = JSON.parse(fixtureJson);
+changed.materials.texts[0].content = JSON.stringify({ text: "EDITED THROUGH MCP", styles: [] });
+changed.tracks[0].segments[0].target_timerange.start += 1_000_000;
+const changedJson = JSON.stringify(changed);
+
+const runtimeEnvironment = {
+  ...process.env,
+  RUST_LOG: "off",
+  XDG_CONFIG_HOME: join(xdgRoot, "config"),
+  XDG_DATA_HOME: join(xdgRoot, "data"),
+  XDG_CACHE_HOME: join(xdgRoot, "cache"),
+};
+
+const loaded = spawnSync(
+  wassette,
+  ["component", "load", pathToFileURL(artifactPath).href, "--component-dir", componentDirectory],
+  { cwd: packageDirectory, env: runtimeEnvironment, encoding: "utf8" },
+);
+assert.equal(loaded.status, 0, loaded.stderr || loaded.error?.message);
+
+const startedAt = performance.now();
+const server = spawn(
+  wassette,
+  ["run", `--component-dir=${componentDirectory}`, "--disable-builtin-tools"],
+  { cwd: packageDirectory, env: runtimeEnvironment, stdio: ["pipe", "pipe", "pipe"] },
+);
+
+let nextId = 1;
+let stderr = "";
+const pending = new Map();
+server.stderr.setEncoding("utf8");
+server.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+
+const lines = createInterface({ input: server.stdout });
+lines.on("line", (line) => {
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (message.id === undefined || !pending.has(message.id)) return;
+  const entry = pending.get(message.id);
+  pending.delete(message.id);
+  clearTimeout(entry.timer);
+  if (message.error) entry.reject(new Error(JSON.stringify(message.error)));
+  else entry.resolve(message.result);
+});
+
+function request(method, params = {}, timeoutMilliseconds = 30_000) {
+  const id = nextId;
+  nextId += 1;
+  return new Promise((resolveRequest, rejectRequest) => {
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      rejectRequest(new Error(`Timeout waiting for ${method}. stderr: ${stderr}`));
+    }, timeoutMilliseconds);
+    pending.set(id, { resolve: resolveRequest, reject: rejectRequest, timer });
+    server.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+  });
+}
+
+function notify(method, params = {}) {
+  server.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds));
+}
+
+function decodeStructured(result) {
+  const structured = result?.structuredContent ?? result?.structured_content;
+  const variant = structured?.result;
+  if (variant && typeof variant === "object" && Object.hasOwn(variant, "ok")) {
+    return { tag: "ok", value: JSON.parse(variant.ok) };
+  }
+  if (variant && typeof variant === "object" && Object.hasOwn(variant, "err")) {
+    return { tag: "err", error: variant.err };
+  }
+  const text = result?.content?.find((item) => item.type === "text")?.text;
+  throw new Error(`Missing structured MCP result: ${text ?? JSON.stringify(result)}`);
+}
+
+async function invoke(name, args, attempts = 1) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const result = await request("tools/call", { name, arguments: args });
+      if (result?.isError) {
+        const message = result.content?.map((item) => item.text ?? "").join(" ") || "MCP tool error";
+        throw new Error(message);
+      }
+      return decodeStructured(result);
+    } catch (error) {
+      lastError = error;
+      if (attempt + 1 < attempts) await sleep(250);
+    }
+  }
+  throw lastError;
+}
+
+function toolEnding(names, ending) {
+  const found = names.find((name) => name.endsWith(`_${ending}`));
+  assert.ok(found, `Missing MCP tool ending in _${ending}: ${names.join(", ")}`);
+  return found;
+}
+
+function direct(result) {
+  return JSON.parse(result);
+}
+
+function percentile(values, fraction) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * fraction))];
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function cliLatencySamples(iterations) {
+  const values = [];
+  for (let index = 0; index < iterations; index += 1) {
+    const before = performance.now();
+    const result = spawnSync(process.execPath, [cliPath, "info", fixturePath], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    JSON.parse(result.stdout);
+    values.push(performance.now() - before);
+  }
+  return values;
+}
+
+try {
+  const initialized = await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "capcut-core-verifier", version: "0.1.0" },
+  });
+  notify("notifications/initialized");
+  const initializedMilliseconds = performance.now() - startedAt;
+
+  const listed = await request("tools/list");
+  const listedNames = listed.tools.map((tool) => tool.name).sort();
+  assert.equal(listedNames.length, 3, `Expected exactly three component tools: ${listedNames.join(", ")}`);
+  assert.ok(!listedNames.some((name) => name.includes("permission") || name === "load-component"));
+  const tools = {
+    inspect: toolEnding(listedNames, "inspect"),
+    lintPortable: toolEnding(listedNames, "lint-portable"),
+    diff: toolEnding(listedNames, "diff"),
+  };
+
+  const firstCallStarted = performance.now();
+  const inspectResult = await invoke(tools.inspect, { "draft-json": fixtureJson }, 80);
+  const firstCallMilliseconds = performance.now() - firstCallStarted;
+  assert.equal(inspectResult.tag, "ok", inspectResult.error);
+  assert.deepEqual(inspectResult.value, direct(__test.inspect(fixtureJson)));
+
+  const lintResult = await invoke(tools.lintPortable, { "draft-json": fixtureJson });
+  assert.equal(lintResult.tag, "ok", lintResult.error);
+  assert.deepEqual(lintResult.value, direct(__test.lintPortable(fixtureJson)));
+
+  const diffResult = await invoke(tools.diff, {
+    "before-json": fixtureJson,
+    "after-json": changedJson,
+  });
+  assert.equal(diffResult.tag, "ok", diffResult.error);
+  assert.deepEqual(diffResult.value, direct(__test.diff(fixtureJson, changedJson)));
+
+  const malformed = await invoke(tools.inspect, { "draft-json": "not-json" });
+  assert.equal(malformed.tag, "err");
+  assert.match(malformed.error, /not valid JSON/);
+  const afterError = await invoke(tools.inspect, { "draft-json": fixtureJson });
+  assert.equal(afterError.tag, "ok");
+
+  const wasmLatencies = [];
+  for (let index = 0; index < 20; index += 1) {
+    const before = performance.now();
+    const value = await invoke(tools.inspect, { "draft-json": fixtureJson });
+    assert.equal(value.tag, "ok");
+    wasmLatencies.push(performance.now() - before);
+  }
+  const cliLatencies = cliLatencySamples(12);
+  const wasmP50 = percentile(wasmLatencies, 0.5);
+  const cliP50 = percentile(cliLatencies, 0.5);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        runtime: { name: "wassette", version: "0.7.0", protocolVersion: initialized.protocolVersion },
+        security: { componentImports: [], builtinToolsExposed: false },
+        mcp: {
+          initializedMs: round(initializedMilliseconds),
+          firstToolCallMs: round(firstCallMilliseconds),
+          tools: listedNames,
+          survivedMalformedInput: true,
+        },
+        parity: { inspect: true, lintPortable: true, diff: true },
+        latencyMs: {
+          warmWasmMcp: {
+            samples: wasmLatencies.length,
+            p50: round(wasmP50),
+            p95: round(percentile(wasmLatencies, 0.95)),
+          },
+          nodeCliProcess: {
+            samples: cliLatencies.length,
+            p50: round(cliP50),
+            p95: round(percentile(cliLatencies, 0.95)),
+          },
+          p50Speedup: round(cliP50 / wasmP50),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  server.kill("SIGTERM");
+}

--- a/wasm/capcut-core/scripts/verify-component.mjs
+++ b/wasm/capcut-core/scripts/verify-component.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const artifactPath = join(packageDirectory, "dist/capcut-core.wasm");
+const jcoPath = join(packageDirectory, "node_modules/.bin/jco");
+const source = readFileSync(join(packageDirectory, "component.js"), "utf8");
+assert.doesNotMatch(source, /^\s*import\s/m, "component source must not import host modules");
+
+const wit = spawnSync(jcoPath, ["wit", artifactPath], { encoding: "utf8" });
+assert.equal(wit.status, 0, wit.stderr);
+assert.doesNotMatch(wit.stdout, /^\s*import\s/m, "component world must have zero imports");
+assert.match(wit.stdout, /^\s*export renezander:capcut-core\/capcut-core;\s*$/m);
+
+const artifact = readFileSync(artifactPath);
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      bytes: statSync(artifactPath).size,
+      sha256: createHash("sha256").update(artifact).digest("hex"),
+      imports: [],
+      declaredExports: ["inspect", "lint-portable", "diff"],
+    },
+    null,
+    2,
+  ),
+);

--- a/wasm/capcut-core/test/core.test.mjs
+++ b/wasm/capcut-core/test/core.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { __test } from "../component.js";
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const fixturePath = resolve(packageDirectory, "../../test/draft_content.json");
+const fixtureJson = readFileSync(fixturePath, "utf8");
+
+function unwrap(result) {
+  return JSON.parse(result);
+}
+
+describe("capcut-core pure contract", () => {
+  it("inspects the repository fixture", () => {
+    const result = unwrap(__test.inspect(fixtureJson));
+    assert.equal(result.id, "test-project-001");
+    assert.equal(result.tracks, 3);
+    assert.equal(result.segments, 6);
+    assert.deepEqual(result.material_summary, [
+      { type: "texts", count: 3 },
+      { type: "videos", count: 2 },
+      { type: "audios", count: 1 },
+      { type: "speeds", count: 1 },
+    ]);
+  });
+
+  it("runs the declared portable lint subset", () => {
+    const broken = JSON.parse(fixtureJson);
+    broken.canvas_config = { ...broken.canvas_config, width: 1080, height: 1920 };
+    const textTrack = broken.tracks.find((track) => track.type === "text");
+    const [first, second, third] = textTrack.segments;
+    const firstText = broken.materials.texts.find((material) => material.id === first.material_id);
+
+    first.target_timerange.duration = 8_000_000;
+    first.clip = { ...(first.clip ?? {}), transform: { ...(first.clip?.transform ?? {}), y: 0.9 } };
+    firstText.content = JSON.stringify({ text: "X".repeat(200), styles: [] });
+    second.target_timerange.start = 1_000_000;
+    second.material_id = "missing-material-id";
+    third.extra_material_refs = ["missing-companion-id"];
+
+    const report = unwrap(__test.lintPortable(JSON.stringify(broken)));
+    assert.equal(report.scope, "portable-subset");
+    assert.deepEqual(report.checks, [
+      "missing-material",
+      "dangling-companion-ref",
+      "cue-too-long",
+      "caption-too-fast",
+      "caption-outside-safe-area",
+      "caption-overlap",
+    ]);
+    assert.deepEqual(
+      new Set(report.issues.map((issue) => issue.code)),
+      new Set(report.checks),
+    );
+    assert.equal(report.ok, false);
+  });
+
+  it("detects material, timing, speed, volume, and content changes", () => {
+    const after = JSON.parse(fixtureJson);
+    after.materials.texts[0].content = JSON.stringify({ text: "EDITED", styles: [] });
+    after.tracks[0].segments[0].target_timerange.start += 1_000_000;
+    after.tracks[0].segments[0].speed = 1.25;
+    after.tracks[0].segments[0].volume = 0.5;
+    const report = unwrap(__test.diff(fixtureJson, JSON.stringify(after)));
+    assert.equal(report.changed, true);
+    assert.deepEqual(report.materials.changed, [after.materials.texts[0].id]);
+    assert.deepEqual(report.segments.changed[0].fields, ["start", "speed", "volume"]);
+  });
+
+  it("rejects malformed input without ambient recovery paths", () => {
+    assert.throws(() => __test.inspect("not-json"), /not valid JSON/);
+  });
+});

--- a/wasm/capcut-core/test/parity.test.mjs
+++ b/wasm/capcut-core/test/parity.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { __test } from "../component.js";
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+const repositoryRoot = resolve(packageDirectory, "../..");
+const fixturePath = resolve(repositoryRoot, "test/draft_content.json");
+const cliPath = resolve(repositoryRoot, "dist/index.js");
+const fixtureJson = readFileSync(fixturePath, "utf8");
+const supportedLintCodes = new Set([
+  "missing-material",
+  "dangling-companion-ref",
+  "cue-too-long",
+  "caption-too-fast",
+  "caption-outside-safe-area",
+  "caption-overlap",
+]);
+
+function invokeCli(args) {
+  const result = spawnSync(process.execPath, [cliPath, ...args], { encoding: "utf8" });
+  assert.notEqual(result.status, null, result.error?.message);
+  assert.ok(result.stdout.trim(), `capcut-cli emitted no JSON: ${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function unwrap(result) {
+  return JSON.parse(result);
+}
+
+function summarize(issues) {
+  const summary = { errors: 0, warnings: 0, info: 0, total: issues.length };
+  for (const issue of issues) {
+    if (issue.severity === "error") summary.errors += 1;
+    else if (issue.severity === "warning") summary.warnings += 1;
+    else summary.info += 1;
+  }
+  return summary;
+}
+
+describe("semantic parity with the repository CLI", () => {
+  it("matches capcut info field-for-field", () => {
+    assert.deepEqual(unwrap(__test.inspect(fixtureJson)), invokeCli(["info", fixturePath]));
+  });
+
+  it("matches the declared portable subset of capcut lint", () => {
+    const broken = JSON.parse(fixtureJson);
+    broken.canvas_config = { ...broken.canvas_config, width: 1080, height: 1920 };
+    const textTrack = broken.tracks.find((track) => track.type === "text");
+    const [first, second, third] = textTrack.segments;
+    const firstText = broken.materials.texts.find((material) => material.id === first.material_id);
+
+    first.target_timerange.duration = 8_000_000;
+    first.clip = { ...(first.clip ?? {}), transform: { ...(first.clip?.transform ?? {}), y: 0.9 } };
+    firstText.content = JSON.stringify({ text: "X".repeat(200), styles: [] });
+    second.target_timerange.start = 1_000_000;
+    second.material_id = "missing-material-id";
+    third.extra_material_refs = ["missing-companion-id"];
+
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "capcut-core-wasm-lint-"));
+    const brokenPath = join(temporaryDirectory, "broken.json");
+    writeFileSync(brokenPath, JSON.stringify(broken));
+
+    const cliReport = invokeCli(["lint", brokenPath, "--no-check-paths", "--no-probe"]);
+    const expectedIssues = cliReport.issues.filter((issue) => supportedLintCodes.has(issue.code));
+    const componentReport = unwrap(__test.lintPortable(JSON.stringify(broken)));
+
+    assert.deepEqual(componentReport.issues, expectedIssues);
+    assert.deepEqual(componentReport.summary, summarize(expectedIssues));
+  });
+
+  it("matches capcut diff field-for-field", () => {
+    const after = JSON.parse(fixtureJson);
+    after.materials.texts[0].content = JSON.stringify({ text: "EDITED BY PARITY TEST", styles: [] });
+    after.tracks[0].segments[0].target_timerange.start += 1_000_000;
+    after.tracks[0].segments[0].speed = 1.25;
+    after.tracks[0].segments[0].volume = 0.5;
+
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "capcut-core-wasm-diff-"));
+    const beforePath = join(temporaryDirectory, "before.json");
+    const afterPath = join(temporaryDirectory, "after.json");
+    writeFileSync(beforePath, fixtureJson);
+    writeFileSync(afterPath, JSON.stringify(after));
+
+    assert.deepEqual(
+      unwrap(__test.diff(fixtureJson, JSON.stringify(after))),
+      invokeCli(["diff", beforePath, afterPath]),
+    );
+  });
+});

--- a/wasm/capcut-core/wit/world.wit
+++ b/wasm/capcut-core/wit/world.wit
@@ -1,0 +1,25 @@
+package renezander:capcut-core;
+
+/// Pure, read-only CapCut and JianYing draft analysis.
+///
+/// Drafts cross the boundary as JSON strings. The component imports no host
+/// capabilities, so it cannot read files, open sockets, inspect environment
+/// variables, launch processes, or access clocks and randomness.
+interface capcut-core {
+    /// Return the same project summary as `capcut info` for a valid draft.
+    inspect: func(draft-json: string) -> result<string, string>;
+
+    /// Run the documented portable subset of `capcut lint`.
+    ///
+    /// This deliberately excludes checks that need host files, media probing,
+    /// bundled catalogues, or version-specific store metadata.
+    lint-portable: func(draft-json: string) -> result<string, string>;
+
+    /// Return the same structural change report as `capcut diff`.
+    diff: func(before-json: string, after-json: string) -> result<string, string>;
+}
+
+/// A capability-free WebAssembly Component for agent-safe draft analysis.
+world capcut-core-component {
+    export capcut-core;
+}


### PR DESCRIPTION
## What

- add an experimental source-only `wasm/capcut-core` package
- expose `inspect`, `diff`, and deliberately scoped `lint-portable` functions as a WebAssembly Component
- keep the component capability-free: JSON in/out with zero filesystem, network, environment, clock, random, stdio, or process imports
- add parity, malformed-input, compiled-world, and raw MCP/Wassette tests
- add a dedicated CI job that uploads the platform-neutral component, SHA-256 checksum, license, and third-party notices
- document Codex/Wassette setup without committing a host binary, local paths, caches, or runtime state

## Why this boundary

`info`, structural `diff`, and a portable lint subset are deterministic draft-data transformations. They benefit from a narrow Wasm sandbox and a long-lived MCP runtime. File discovery, media probing, store/version checks, writes, rendering, and network-backed operations remain in the Node CLI.

The lint function is named `lint-portable` rather than `lint` because it only promises six parity-tested checks: `missing-material`, `dangling-companion-ref`, `cue-too-long`, `caption-too-fast`, `caption-outside-safe-area`, and `caption-overlap`.

## Verification

- `npm run wasm:verify`: 7/7 contract and current-CLI parity tests passed
- compiled component: 11,626,347 bytes; zero Component Model imports
- Wassette 0.7.0 raw MCP test: exactly three component tools, built-in management tools disabled, all calls matched direct results, and the server recovered after malformed JSON
- current local benchmark: 20 warm MCP calls p50 0.90 ms versus 12 fresh CLI processes p50 54.77 ms (61.06x); first Wasm call was 260.47 ms, so this is a repeated-call/session win rather than a cold-call claim
- full repository suite: 865/865 passed
- repository lint passed
- root and Wasm package npm audits: zero vulnerabilities
- staged public-diff scan: no credentials, private keys, personal filesystem paths, bundled binaries, or runtime state

## Supply-chain and publication hygiene

- ComponentizeJS 0.19.3 and Jco 1.17.9 are exact-pinned with a committed lockfile; this compatible line is clean under the current npm audit, unlike the latest toolchain dependency graph at implementation time
- CI downloads the official Wassette 0.7.0 Linux archive and verifies GitHub's published SHA-256 digest before use
- generated `.wasm`, Wassette binaries, component caches, and runtime directories stay ignored
- generated artifacts carry the repository license, third-party notices, and a SHA-256 checksum
