### PR TITLE
release: v0.22.0 — nine opportunity-mined items (draft_materials registration, captions across the NLE handoff, retake detection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,96 @@ All notable changes to capcut-cli are documented here. The format follows [Keep 
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-09-04
+
+Nine items, each mined from a pain users are hitting now — this repo's own
+threads, the forks ahead of it, the downstream projects that build on it
+(vertir, qcut, OpenChatCut) and the neighbouring CapCut/JianYing libraries —
+and each checked against what the CLI already did before it was built. The
+cross-repo intersection was thin this cycle (the repo is mature; most hot
+ecosystem pains are already shipped here), so the list leans on Tier-1
+evidence: the sidecar registration is the one item with a concrete, reproduced
+app failure behind it; the OTIO, script-alignment and retake items ride
+long-standing asks in neighbouring tools; the last four are ergonomics the
+downstream integrators and the most-diverged fork had to build for themselves.
+No command was removed, no existing flag changed meaning, and every existing
+JSON output keeps its shape — new fields appear only when the new flag is used.
+
+### Added
+
+- **`register --materials` — the CapCut 9.1 "file inaccessible" fix ([pyCapCut#13](https://github.com/GuanYixuan/pyCapCut/issues/13))** —
+  newer builds decide which media is imported from draft_meta_info.json's `draft_materials`, not from the timeline's
+  paths, so every tool-built draft (this CLI's included: the sidecar's groups were always empty) opened with each clip
+  shown as inaccessible and a relink prompt. v0.21 could only observe the empty state (`media-unregistered`);
+  `--materials` writes the registration: one type-0 entry per distinct local file, matched by `file_Path`, shape per
+  pyCapCut PR [#14](https://github.com/GuanYixuan/pyCapCut/pull/14) (verified by its author against the 9.1.0 prompt;
+  photos get the 5 s nominal duration, audio registers as `music`). It folds into register's own sidecar write — a
+  missing sidecar is recreated and registered in one write, one `.bak`, one changed-on-disk check — merges rather than
+  replaces (app-written entries untouched), and re-runs are no-ops. `lint`'s `media-unregistered` note and `diagnose`
+  now name the command instead of asking for a fixture first; an app-authored 9.1 sidecar is still welcome as ground
+  truth (`docs/draft-schema/00-overview.md` records what is measured and what is inferred).
+- **`export-timeline --captions markers` + caption import in `import-timeline`** — OTIO has had no title/subtitle
+  schema since the request was opened in 2017 ([OpenTimelineIO#62](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/62),
+  [#805](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/805) still WIP), so the export dropped every
+  text track. With `--captions markers` each cue becomes a `Marker.1` on the Stack — name = cue text, `marked_range` =
+  cue timing, `metadata.capcut.kind = "caption"` plus the text and track name, and Resolve's own `Resolve_OTIO.Note` so
+  the text shows in its marker panel — which Resolve/Premiere import as timeline markers. `import-timeline` turns
+  flagged caption markers back into text segments on the recorded track name (de-collided like the clip tracks) and
+  reports any foreign timeline marker instead of dropping it. Default stays `skip`, so today's documents are
+  byte-identical; the skip note now points at the flag.
+- **`caption --script <file>` — whisper's timing, your wording** — names, product terms and punctuation are what speech
+  recognition gets wrong most, and the pipelines that most want burned-in captions already have the script
+  (neo9su/autoclipvideo#174, baizhiheizi/enjoy_player#540 both ask for word timing on a KNOWN text). The script and the
+  recognised words are aligned globally (Needleman–Wunsch on normalised tokens, with a near-miss term so
+  "chanel"/"channel" pair with each other rather than with a neighbour); every script word inherits its recognised
+  word's start/end, unheard words are spread across the gap between timed neighbours. Each non-empty script line is a
+  cue (split only past `--max-chars`); with `--karaoke` the timed script words group as usual. The result's `script`
+  block reports matched / substituted / inserted / dropped words and the match ratio; below 50 % it warns that the
+  script probably belongs to other audio.
+- **`detect-retakes` — the repeat the silence pass cannot see** — talking-head recordings are full of second attempts;
+  the one ecosystem tool that tried (mrbuslov/capcut-ai-editor, [PR #3](https://github.com/mrbuslov/capcut-ai-editor/pull/3))
+  shows the failure to design against: its sentence-similarity pass matched unrelated sentences 27 minutes apart and
+  collapsed a 29-minute recording to 1:47. Three explicit guards here: a `--window` (later take must start within 60 s
+  of the earlier one ending), `--min-words` (cues under 4 normalised words never count — "okay so" repeats constantly),
+  and a `--similarity` floor on the word sequences (2·LCS/(a+b), default 0.8, so a rephrased sentence is not a repeat).
+  The later take is the keeper; earlier spans become cuts, merged where they touch, with the complementary keep spans
+  in seconds and microseconds — the detect-silence shape, so `cut`/`compile` consume it unchanged. Reads the draft's
+  text tracks (or one `--track-name`) or `--srt <file>` with no draft; never writes.
+- **`render --soft-captions`** — a toggleable `mov_text` subtitle stream in the proxy instead of (or as well as) pixels
+  burned in (munimtechnologies/munim-ffmpeg#3, home-lang/home-os#86 — "soft subtitle muxing"). The cues are written
+  as `<preview>.srt` next to the output (players auto-load it by name anyway) and muxed as stream `0:s:0`; a build
+  without the `mov_text` encoder skips with a note like the drawtext fallback. The plan drops `-shortest` only when a
+  subtitle stream is muxed, because ffmpeg would otherwise end the file at the last cue.
+- **Keyframe property aliases** — `scale` (= `uniform_scale`), `x`, `y`, `opacity` are accepted by `keyframe`,
+  `keyframe --batch` and compile's keyframe op and stored under the canonical `property_type`; the two downstream IR
+  compilers built on this CLI (FullFran/vertir's PROP_MAP, Quriosity-agent/qcut's spec.py) had each re-implemented the
+  same translation table. `describe`/`--help` list both forms; the error for an unknown name lists the aliases.
+- **`keyframe --easing hold`** — the step easing the same integrators carried in their IR and had to degrade to linear
+  because CapCut always interpolates. The step is emulated the way an editor does it by hand: a helper keyframe with
+  the held value one frame before the NEXT keyframe on that property, so the whole ramp happens inside one frame.
+  Works in `--batch` even when the held keyframe is named before its pair; a hold with no later keyframe, or one whose
+  neighbour already carries the value, is reported (`hold_keyframes`, warnings) rather than invented. The schema docs
+  list a `"Hold"` curveType, but no app-authored draft carries it, so the CLI does not write an unverified encoding.
+- **`matting <project> <segment-id> [--off]` — smart matting / "Remove background" / 智能抠像** — writes `flag: 3`
+  (smart portrait matting) on the segment's VIDEO MATERIAL and leaves the cache fields at their empty defaults for the
+  app to fill on next open; `--off` writes the documented flag-0 object back, keeping any app-authored cache. Encoding
+  per the pyJianYingDraft contributor PRs [#183](https://github.com/GuanYixuan/pyJianYingDraft/pull/183)/[#184](https://github.com/GuanYixuan/pyJianYingDraft/pull/184)
+  (built twice, never merged); provenance recorded in `docs/draft-schema/02-materials.md`. Per material: segments
+  sharing the material are reported as `shared_segments`.
+- **`init` / `quickstart` `--ratio 9:16` (or `--width/--height`)** — the bundled template is 1920×1080, so a portrait
+  short needed a `compile` spec or a second step; the most-diverged community fork shipped `init --width/--height` for
+  exactly this. Presets at CapCut's native sizes (`16:9`, `9:16`, `1:1`, `4:3`, `3:4`); explicit width+height win over
+  the preset's size and keep its label (or get `"original"`). The canvas is stamped into every timeline file the
+  template ships, so the mirrors never disagree; without the flags the template canvas is kept and the output carries
+  `canvas: null`.
+
+### Changed
+
+- `lint`'s `media-unregistered` issue suggests `capcut register <project> --materials --apply` (it used to ask for a
+  `fixture` bundle); still info-severity and `fixable: false` — a sidecar write is register's job, not `lint --fix`'s.
+- `diagnose`'s media-registration note names the same repair.
+- `export-timeline` reports text tracks as skipped with a pointer to `--captions markers` as well as `export-srt`.
+
 ## [0.21.1] — 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ The host reads a draft and passes its JSON as tool input. The component itself h
 
 ## Release notes
 
+> **New in v0.22.0:** nine items mined from what users are hitting across this repo, its forks and the wider CapCut/JianYing tooling. `register --materials` writes the `draft_materials` registration CapCut 9.1 reads to decide what is imported — the fix for every clip showing as "file inaccessible" with a relink prompt ([pyCapCut#13](https://github.com/GuanYixuan/pyCapCut/issues/13)). `export-timeline --captions markers` carries caption cues into the NLE as OTIO timeline markers, and `import-timeline` rebuilds the text track from them (OTIO has no title schema — [OpenTimelineIO#62](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/62), open since 2017). `caption --script` keeps whisper's word timing but uses your script's wording. `detect-retakes` finds the sentence the speaker fluffed and said again, with the window / min-words / similarity guards that keep it from collapsing a timeline. Plus `render --soft-captions` (a toggleable mov_text stream), `matting` (smart background removal on a clip's material), `init --ratio 9:16` for portrait drafts, IR-style keyframe aliases (`scale`, `x`, `y`, `opacity`) and `--easing hold`. No command was removed and no existing output changed shape. Full details in the [changelog](./CHANGELOG.md).
+
 > **New in v0.21.1:** one fix, and if you run the CLI via `npx` it is the whole release: the `refused [editor-open]` guard was detecting the CLI's *own* npm process — npm rewrites its process title to the full command line, which contains `capcut-cli`, and the guard substring-matched the joined process table — so every write on the documented zero-install path (`npx capcut-cli …`) was refused even with CapCut closed ([#99](https://github.com/renezander030/capcut-cli/issues/99), reported by [@hansuk94](https://github.com/hansuk94) with the diagnosis and the fix direction included). Editor detection now compares exact process names, per process, on macOS, Linux and Windows — a really-running CapCut/JianYing still refuses, npm never does. Full details in the [changelog](./CHANGELOG.md).
 
-> **New in v0.21.0:** the CapCut Mac 9.2.8 nested-Timelines report ([#50](https://github.com/renezander030/capcut-cli/issues/50)) gets its repair path — `sync-timelines --nested` copies the root timeline into the `Timelines/<id>/` documents as an explicit opt-in, each document keeping its own GUID (the workaround verified in the thread), and `fixture --check` mechanically verifies a bundle leaks no home path, email or device id before you attach it. Every write refusal now names its gate (`refused [editor-open]` / `[version-boundary]` / `[draft-changed-on-disk]`), so a pasted stderr line is unambiguous. Plus `catalogue <query>` — name → resource_id across every bundled and harvested table, `lint --pip` for the PIP + local-mask workflow ([#78](https://github.com/renezander030/capcut-cli/issues/78)), `import-srt --clone-style` (keep the draft's caption look without hunting a segment id), `relink --stage` (the repaired draft leaves portable), an observe-only `media-unregistered` note (pyCapCut#13), and Chinese docs for version support and encryption. No command was removed and no existing flag changed meaning. Full details in the [changelog](./CHANGELOG.md).
 
 ## Commands
 
@@ -99,8 +100,8 @@ JSON by default (pipe to `jq`); add `-H` for a human-readable table. Pass `--jia
 | **Edit / animate** | trim · speed · volume · transitions · masks · text/image animations · easing curves |
 | **Templates** | apply and extract reusable layouts · `make-preset` (portable text-style presets) |
 | **Subtitles & i18n** | `caption` · `import-srt` · `export-srt` (line/word SRT + VTT) · `translate` (multi-language draft clone) |
-| **Effects** | `sfx` · `chroma` (chroma key) |
-| **Long-form → short** | `cut` · `detect-scenes` (ffmpeg scene-cut detection) |
+| **Effects** | `sfx` · `chroma` (chroma key) · `matting` (smart background removal) |
+| **Long-form → short** | `cut` · `detect-scenes` (ffmpeg scene-cut detection) · `detect-silence` · `detect-retakes` (repeated takes) |
 | **Automation** | `serve` (stateless JSONL runner) · `migrate` · `doctor` · `sync-timelines` (8.7 mirror repair) |
 
 **Full reference** for every command, option, and exit code: **[docs/command-reference.md](./docs/command-reference.md)** (简体中文: [docs/command-reference.zh-CN.md](./docs/command-reference.zh-CN.md)).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,9 +57,10 @@ JSON 进、JSON 出：每个命令都直接读写本地草稿存储，不用 MCP
 
 ## 发布说明
 
+> **v0.22.0 新增：** 九项来自本仓库、其分支及更广泛 CapCut/剪映工具生态中真实用户痛点的功能。`register --materials` 会写入 CapCut 9.1 用来判断素材是否已导入的 `draft_materials` 登记——修复所有片段显示为"文件无法访问"并要求重新链接的问题（[pyCapCut#13](https://github.com/GuanYixuan/pyCapCut/issues/13)）。`export-timeline --captions markers` 把字幕作为 OTIO 时间线标记带进 NLE，`import-timeline` 再由这些标记重建文本轨道（OTIO 没有字幕/标题 schema——[OpenTimelineIO#62](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/62)，自 2017 年悬而未决）。`caption --script` 保留 whisper 的逐词时间，但采用你的脚本文字。`detect-retakes` 找出说错后重说的句子，并以窗口、最少词数、相似度三道守卫防止误剪整条时间线。另有 `render --soft-captions`（可开关的 mov_text 字幕流）、`matting`（对片段素材开启智能抠像）、`init --ratio 9:16`（竖版草稿）、IR 风格的关键帧属性别名（`scale`、`x`、`y`、`opacity`）与 `--easing hold`。没有删除任何命令，现有输出结构均未改变。详见[更新日志](./CHANGELOG.md)。
+
 > **v0.21.1 新增：** 只有一个修复，但如果你通过 `npx` 使用 CLI，它就是这个版本的全部：`refused [editor-open]` 守卫会把 CLI *自己的* npm 进程识别为正在运行的编辑器——npm 会把自身进程标题改写为完整命令行（其中含有 `capcut-cli`），而守卫对拼接后的整张进程表做子串匹配——因此在文档记载的免安装路径（`npx capcut-cli …`）上，即使 CapCut 已关闭，所有写入也一律被拒绝（[#99](https://github.com/renezander030/capcut-cli/issues/99)，由 [@hansuk94](https://github.com/hansuk94) 报告，诊断与修复方向随报告一并给出）。编辑器检测现在在 macOS、Linux 与 Windows 上都按进程逐个精确比较进程名——真正运行中的 CapCut/JianYing 仍会拒绝写入，npm 进程不再触发。详见[更新日志](./CHANGELOG.md)。
 
-> **v0.21.0 新增：** issue [#50](https://github.com/renezander030/capcut-cli/issues/50) 中 CapCut Mac 9.2.8 嵌套 Timelines 布局的报告有了修复路径——`sync-timelines --nested` 以显式选择的方式把根时间线复制进 `Timelines/<id>/` 文档（每个文档保留自己的 GUID，即讨论串中验证过的解决办法），`fixture --check` 会在你附上诊断包之前机械化地检查是否残留家目录路径、邮箱或设备 ID。每次写入拒绝现在都会标明触发的守卫（`refused [editor-open]` / `[version-boundary]` / `[draft-changed-on-disk]`），粘贴的 stderr 不再有歧义。另有 `catalogue <query>`（按名称在全部内置与采集目录中查 resource_id）、`lint --pip`（画中画+蒙版工作流校验，[#78](https://github.com/renezander030/capcut-cli/issues/78)）、`import-srt --clone-style`（无需先查段 ID 即沿用草稿现有字幕样式）、`relink --stage`（修复后的草稿可随文件夹迁移）、只观察不写入的 `media-unregistered` 提示（pyCapCut#13），以及 version-support 与 jianying-encryption 的中文文档。没有删除任何命令，现有参数含义均未改变。详见[更新日志](./CHANGELOG.md)。
 
 ## 常用命令
 
@@ -75,8 +76,8 @@ JSON 进、JSON 出：每个命令都直接读写本地草稿存储，不用 MCP
 | **编辑 / 动画** | 裁剪 · 变速 · 音量 · 转场 · 蒙版 · 文字/图片动画 · 缓动曲线 |
 | **模板** | 应用与提取可复用版式 · `make-preset`（可移植文字样式预设）|
 | **字幕 / 多语言** | `caption` · `import-srt` · `export-srt`（行级/逐词 SRT + VTT）· `translate`（多语言草稿克隆）|
-| **特效** | `sfx` · `chroma`（绿幕抠像）|
-| **长视频切短** | `cut` · `detect-scenes`（ffmpeg 场景切点检测）|
+| **特效** | `sfx` · `chroma`（绿幕抠像）· `matting`（智能抠像/去背景）|
+| **长视频切短** | `cut` · `detect-scenes`（ffmpeg 场景切点检测）· `detect-silence` · `detect-retakes`（重复口播段落）|
 | **自动化** | `serve`（无状态 JSONL 执行器）· `migrate` · `doctor` · `sync-timelines`（8.7 时间线镜像修复）|
 
 **完整命令参考**（每个命令、参数与退出码）：**[docs/command-reference.zh-CN.md](./docs/command-reference.zh-CN.md)**（[英文原版](./docs/command-reference.md)）。

--- a/docs/command-reference.json
+++ b/docs/command-reference.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "schema_version": 2,
   "description": "Edit CapCut/JianYing draft_content.json directly. JSON in, JSON out.",
   "global_flags": [
@@ -669,7 +669,7 @@
     {
       "name": "export-timeline",
       "summary": "Export video/audio tracks as OpenTimelineIO JSON for NLE handoff (DaVinci Resolve imports .otio natively).",
-      "usage": "capcut export-timeline <project> [--out <file.otio>]",
+      "usage": "capcut export-timeline <project> [--out <file.otio>] [--captions skip|markers]",
       "positionals": [
         {
           "name": "project",
@@ -691,6 +691,20 @@
           "type": "path",
           "required": false,
           "description": "Output path."
+        },
+        {
+          "name": "captions",
+          "flags": [
+            "--captions"
+          ],
+          "type": "enum",
+          "required": false,
+          "description": "Text/caption tracks: skip them with a note (default), or write every cue as an OTIO timeline marker on the Stack (name = text, marked_range = timing, metadata.capcut.kind = caption) — Resolve/Premiere import those as timeline markers and import-timeline rebuilds the text track from them.",
+          "values": [
+            "skip",
+            "markers"
+          ],
+          "default": "skip"
         }
       ],
       "mutates": false,
@@ -1516,12 +1530,13 @@
           ],
           "type": "enum",
           "required": false,
-          "description": "Interpolation easing to adjacent keyframes. Needs an adjacent keyframe on the same property; a lone eased keyframe stays linear (warns).",
+          "description": "Interpolation easing to adjacent keyframes. Needs an adjacent keyframe on the same property; a lone eased keyframe stays linear (warns). hold = step: the value is held by a helper keyframe one frame before the next keyframe on that property (needs a later keyframe; warns otherwise).",
           "values": [
             "linear",
             "ease-in",
             "ease-out",
-            "ease-in-out"
+            "ease-in-out",
+            "hold"
           ],
           "default": "linear"
         }
@@ -3561,6 +3576,15 @@
       ],
       "options": [
         {
+          "name": "script",
+          "flags": [
+            "--script"
+          ],
+          "type": "path",
+          "required": false,
+          "description": "Known transcript (plain text). Whisper's word timing is kept, the script's wording is used; each non-empty line is a cue boundary. The result's `script` block reports matched/substituted/inserted words."
+        },
+        {
           "name": "audio",
           "flags": [
             "--audio"
@@ -3957,6 +3981,44 @@
       }
     },
     {
+      "name": "matting",
+      "summary": "Smart matting (background removal) on a video/photo segment's material — flag 3 on; --off writes the documented flag-0 object.",
+      "usage": "capcut matting <project> <id> [--off]",
+      "positionals": [
+        {
+          "name": "project",
+          "type": "path",
+          "required": true
+        },
+        {
+          "name": "id",
+          "type": "id",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "off",
+          "flags": [
+            "--off"
+          ],
+          "type": "boolean",
+          "required": false,
+          "description": "Turn smart matting off: writes the documented flag-0 matting object on the segment's video material (cache fields kept)."
+        }
+      ],
+      "mutates": true,
+      "prerequisites": [],
+      "output": {
+        "type": "object",
+        "description": "JSON by default; use -H where supported for human output."
+      },
+      "exit_codes": {
+        "0": "success",
+        "1": "invalid input, warning, or operation failure"
+      }
+    },
+    {
       "name": "prune",
       "summary": "Remove materials no segment references.",
       "usage": "capcut prune <project>",
@@ -3981,8 +4043,8 @@
     },
     {
       "name": "register",
-      "summary": "Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak).",
-      "usage": "capcut register <project-dir> [--apply] [--drafts <dir>]",
+      "summary": "Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak); --materials also registers the timeline's media in draft_materials (the CapCut 9.1 relink-prompt fix).",
+      "usage": "capcut register <project-dir> [--apply] [--materials] [--drafts <dir>]",
       "positionals": [
         {
           "name": "project-dir",
@@ -4004,6 +4066,15 @@
           "type": "boolean",
           "required": false,
           "description": "Write the repaired draft_meta_info.json / root_meta_info.json entry (default: print the plan only)."
+        },
+        {
+          "name": "materials",
+          "flags": [
+            "--materials"
+          ],
+          "type": "boolean",
+          "required": false,
+          "description": "Also register the timeline's local media in draft_meta_info.json's draft_materials (the list CapCut 9.1 uses to decide what is imported; empty, every clip shows as 'file inaccessible'). Appends missing entries to the type-0 group, preserves existing ones, no-ops when complete."
         },
         {
           "name": "drafts",
@@ -4925,7 +4996,7 @@
     {
       "name": "init",
       "summary": "Create a new empty draft from a template.",
-      "usage": "capcut init <name> [--template <dir>] [--drafts <dir>]",
+      "usage": "capcut init <name> [--template <dir>] [--drafts <dir>] [--ratio <r> | --width <px> --height <px>]",
       "positionals": [
         {
           "name": "name",
@@ -4935,6 +5006,11 @@
         {
           "name": "dir",
           "type": "path",
+          "required": false
+        },
+        {
+          "name": "r",
+          "type": "string",
           "required": false
         }
       ],
@@ -4956,6 +5032,40 @@
           "type": "path",
           "required": false,
           "description": "Draft root directory."
+        },
+        {
+          "name": "ratio",
+          "flags": [
+            "--ratio"
+          ],
+          "type": "enum",
+          "required": false,
+          "description": "Canvas aspect preset at the size CapCut uses for it (16:9 = 1920x1080, the template default; 9:16 = 1080x1920 portrait). Explicit --width/--height win over the preset's size but keep its label.",
+          "values": [
+            "16:9",
+            "9:16",
+            "1:1",
+            "4:3",
+            "3:4"
+          ]
+        },
+        {
+          "name": "width",
+          "flags": [
+            "--width"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Exact canvas width in pixels (requires --height)."
+        },
+        {
+          "name": "height",
+          "flags": [
+            "--height"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Exact canvas height in pixels (requires --width)."
         }
       ],
       "mutates": true,
@@ -4972,7 +5082,7 @@
     {
       "name": "quickstart",
       "summary": "One-command first draft: create + add one input + lint + print the open-in-CapCut step.",
-      "usage": "capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>]",
+      "usage": "capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>] [--ratio <r> | --width <px> --height <px>]",
       "positionals": [
         {
           "name": "name",
@@ -4987,6 +5097,11 @@
         {
           "name": "dir",
           "type": "path",
+          "required": false
+        },
+        {
+          "name": "r",
+          "type": "string",
           "required": false
         }
       ],
@@ -5044,6 +5159,40 @@
           "type": "path",
           "required": false,
           "description": "ffprobe binary for duration detection."
+        },
+        {
+          "name": "ratio",
+          "flags": [
+            "--ratio"
+          ],
+          "type": "enum",
+          "required": false,
+          "description": "Canvas aspect preset at the size CapCut uses for it (16:9 = 1920x1080, the template default; 9:16 = 1080x1920 portrait). Explicit --width/--height win over the preset's size but keep its label.",
+          "values": [
+            "16:9",
+            "9:16",
+            "1:1",
+            "4:3",
+            "3:4"
+          ]
+        },
+        {
+          "name": "width",
+          "flags": [
+            "--width"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Exact canvas width in pixels (requires --height)."
+        },
+        {
+          "name": "height",
+          "flags": [
+            "--height"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Exact canvas height in pixels (requires --width)."
         }
       ],
       "mutates": true,
@@ -5222,6 +5371,15 @@
           "type": "boolean",
           "required": false,
           "description": "Burn captions."
+        },
+        {
+          "name": "soft_captions",
+          "flags": [
+            "--soft-captions"
+          ],
+          "type": "boolean",
+          "required": false,
+          "description": "Mux the text-track cues as a toggleable mov_text subtitle stream (the SRT is also written next to the output as <preview>.srt); skipped with a note when ffmpeg has no mov_text encoder."
         },
         {
           "name": "all_video_tracks",
@@ -5422,6 +5580,97 @@
         "ffmpeg",
         "ffprobe (optional)"
       ],
+      "output": {
+        "type": "object",
+        "description": "JSON by default; use -H where supported for human output."
+      },
+      "exit_codes": {
+        "0": "success",
+        "1": "invalid input, warning, or operation failure"
+      }
+    },
+    {
+      "name": "detect-retakes",
+      "summary": "Find repeated takes in the draft's captions (or an SRT): windowed word-sequence similarity, later take kept; prints cuts + keep segments to seed compile/cut.",
+      "usage": "capcut detect-retakes <project> [--track-name <s>] [--window <s>] [--similarity <n>] [--min-words <n>] | --srt <file>",
+      "positionals": [
+        {
+          "name": "project",
+          "type": "path",
+          "required": true
+        },
+        {
+          "name": "s",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "n",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "options": [
+        {
+          "name": "track_name",
+          "flags": [
+            "--track-name"
+          ],
+          "type": "string",
+          "required": false,
+          "description": "Target track name."
+        },
+        {
+          "name": "srt",
+          "flags": [
+            "--srt"
+          ],
+          "type": "path",
+          "required": false,
+          "description": "Read cues from this SRT file instead of a draft (no <project> then)."
+        },
+        {
+          "name": "window",
+          "flags": [
+            "--window"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Max seconds between the earlier cue's end and the later cue's start.",
+          "default": 60
+        },
+        {
+          "name": "similarity",
+          "flags": [
+            "--similarity"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Word-sequence similarity floor, 0..1 (2·LCS/(a+b)).",
+          "default": 0.8
+        },
+        {
+          "name": "min_words",
+          "flags": [
+            "--min-words"
+          ],
+          "type": "number",
+          "required": false,
+          "description": "Cues with fewer normalised words never count as a take.",
+          "default": 4
+        },
+        {
+          "name": "json",
+          "flags": [
+            "--json"
+          ],
+          "type": "boolean",
+          "required": false,
+          "description": "Force JSON output (the default; overrides -H)."
+        }
+      ],
+      "mutates": false,
+      "prerequisites": [],
       "output": {
         "type": "object",
         "description": "JSON by default; use -H where supported for human output."

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -19,7 +19,7 @@
 | `opacity` | `capcut opacity <project> <id> <alpha>` | yes | Set a segment's opacity (0.0-1.0). |
 | `export-srt` | `capcut export-srt <project> [options]` | no | Export subtitles to SRT or WebVTT on stdout, per line or per word. |
 | `export-ass` | `capcut export-ass <project> [--karaoke] [--out <file.ass>]` | no | Export styled ASS subtitles on stdout or --out, with per-range overrides and --karaoke word timing. |
-| `export-timeline` | `capcut export-timeline <project> [--out <file.otio>]` | no | Export video/audio tracks as OpenTimelineIO JSON for NLE handoff (DaVinci Resolve imports .otio natively). |
+| `export-timeline` | `capcut export-timeline <project> [--out <file.otio>] [--captions skip\|markers]` | no | Export video/audio tracks as OpenTimelineIO JSON for NLE handoff (DaVinci Resolve imports .otio natively). |
 | `import-timeline` | `capcut import-timeline <file.otio> (--out <new-project> \| --into <project>)` | yes | Import OpenTimelineIO JSON (the export-timeline schema set) as a new draft (--out) or append it onto an existing one (--into); unsupported OTIO features are reported, never silent. |
 | `materials` | `capcut materials <project> [--type <type>]` | no | List material types and counts; filter with --type. |
 | `segment` | `capcut segment <project> <id>` | no | Full detail for one segment and its material. |
@@ -59,8 +59,9 @@
 | `migrate` | `capcut migrate <project> --from <version> --to <version>` | yes | Apply known schema migrations across version boundaries. |
 | `add-sfx` | `capcut add-sfx <project> <slug> <start> <duration> [options]` | yes | Add a sound effect on a dedicated track. |
 | `chroma` | `capcut chroma <project> <id> (--color <hex> \| --off) [options]` | yes | Green-screen / chroma key a video segment, or --off. |
+| `matting` | `capcut matting <project> <id> [--off]` | yes | Smart matting (background removal) on a video/photo segment's material — flag 3 on; --off writes the documented flag-0 object. |
 | `prune` | `capcut prune <project>` | yes | Remove materials no segment references. |
-| `register` | `capcut register <project-dir> [--apply] [--drafts <dir>]` | yes | Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak). |
+| `register` | `capcut register <project-dir> [--apply] [--materials] [--drafts <dir>]` | yes | Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak); --materials also registers the timeline's media in draft_materials (the CapCut 9.1 relink-prompt fix). |
 | `rename` | `capcut rename <project> <new-name> [--drafts <dir>]` | yes | Rename a draft after creation: the folder on disk plus draft_name and every self-referential path in draft_meta_info.json and the store's root_meta_info.json entry, transactionally (refuses when the target folder exists). |
 | `relink` | `capcut relink <project> (--dir <path> \| --from <prefix> --to <prefix>) [--stage]` | yes | Repair broken media paths (--dir or --from/--to). |
 | `replace-media` | `capcut replace-media <project> <segment-id> <new-file> [--retime]` | yes | Swap a segment's source file (placeholder > final) keeping its timing, effects, and keyframes. |
@@ -82,9 +83,10 @@
 | `serve` | `capcut serve [--queue <path>] [options]` | no | Run a stateless JSONL job queue from stdin/--queue. |
 | `decrypt` | `capcut decrypt <project-or-file>` | no | Detect JianYing 6.0+ encryption and explain the workaround. |
 | `export` | `capcut export <drafts-dir> --batch [options]` | yes | EXPERIMENTAL UI-automated render queue (macOS). |
-| `init` | `capcut init <name> [--template <dir>] [--drafts <dir>]` | yes | Create a new empty draft from a template. |
-| `quickstart` | `capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>]` | yes | One-command first draft: create + add one input + lint + print the open-in-CapCut step. |
+| `init` | `capcut init <name> [--template <dir>] [--drafts <dir>] [--ratio <r> \| --width <px> --height <px>]` | yes | Create a new empty draft from a template. |
+| `quickstart` | `capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>] [--ratio <r> \| --width <px> --height <px>]` | yes | One-command first draft: create + add one input + lint + print the open-in-CapCut step. |
 | `compile` | `capcut compile <spec.json> [--out <draftdir>] [--data <rows.jsonl\|->] [--check \| --plan]` | yes | Build a draft from a declarative JSON spec (the inverse of describe). |
 | `render` | `capcut render <project> [--out <preview.mp4>] [options]` | no | Render a low-res ffmpeg proxy preview (trim+speed+audio, --burn-captions); not CapCut's final render. |
 | `detect-scenes` | `capcut detect-scenes <video> [options]` | no | Detect scene-change cut points in a video (ffmpeg scene filter); prints cuts + segments to seed compile/cut. |
 | `detect-silence` | `capcut detect-silence <media> [options]` | no | Detect silence spans in a media file (ffmpeg silencedetect); prints silences + keep segments to seed compile/cut. |
+| `detect-retakes` | `capcut detect-retakes <project> [--track-name <s>] [--window <s>] [--similarity <n>] [--min-words <n>] \| --srt <file>` | no | Find repeated takes in the draft's captions (or an SRT): windowed word-sequence similarity, later take kept; prints cuts + keep segments to seed compile/cut. |

--- a/docs/draft-schema/00-overview.md
+++ b/docs/draft-schema/00-overview.md
@@ -110,6 +110,48 @@ Every write command in `capcut-cli`:
 
 The `.bak` is your safety net — if CapCut crashes on open, restore from `.bak`. Close CapCut on the project before editing, reopen after.
 
+## `draft_meta_info.json` — the sidecar the app trusts for "what is imported"
+
+The per-draft sidecar carries the registration fields (`draft_id`,
+`draft_fold_path`, `draft_json_file`, `draft_name`, `draft_root_path`,
+`tm_*`) that `capcut register` repairs, plus `draft_materials`: an array of
+groups `{ "type": N, "value": [ … ] }`. Group `type: 0` lists the media the
+user IMPORTED. Newer builds (reported on CapCut International 9.1.0, macOS —
+[pyCapCut#13](https://github.com/GuanYixuan/pyCapCut/issues/13)) decide from
+this list, not from the timeline's material paths, which clips are available:
+a tool-built sidecar whose groups are all empty opens with every clip shown as
+"file inaccessible" and a relink prompt, even though the paths in
+`draft_content.json` are valid. `capcut lint` reports the empty state as
+`media-unregistered`; `capcut register <project> --materials --apply` writes the
+registration (v0.22, `src/materials-register.ts`).
+
+One entry per distinct local file, matched by `file_Path`:
+
+```jsonc
+{
+  "ai_group_type": "", "create_time": -1,
+  "duration": 3000000,            // µs; photos: 5000000 nominal
+  "enter_from": 0, "extra_info": "clip.mp4",   // display name
+  "file_Path": "/abs/or/relative/path/clip.mp4",
+  "height": 1080, "id": "<uuid>",
+  "import_time": -1, "import_time_ms": -1, "item_source": 1,
+  "material_color_tag": "", "md5": "",
+  "metetype": "video",            // "video" | "photo" | "music"
+  "roughcut_time_range": { "duration": -1, "start": -1 },
+  "sub_time_range": { "duration": -1, "start": -1 },
+  "type": 0, "width": 1920
+}
+```
+
+**Provenance, and what is still inferred:** the shape is pyCapCut PR
+[#14](https://github.com/GuanYixuan/pyCapCut/pull/14) (gingatimo, 2026-08-18),
+verified by its author against the 9.1.0 relink prompt; `-1` timestamps and an
+empty `md5` are what the app accepts for a manual import. No app-authored 9.1
+sidecar is committed here yet — `capcut fixture` on a draft the app itself
+imported media into would confirm the shape byte-for-byte (the bundle includes
+`draft_meta_info.json`). The CLI merges, never replaces: existing entries stay,
+missing files are appended to the type-0 group, re-runs are no-ops.
+
 ## Common gotchas
 
 - **CapCut MUST be closed on the draft before edit.** CapCut periodically rewrites the file from in-memory state; editing while open = your changes overwritten on next save. `capcut-cli` does not enforce this, but you'll lose data if you skip it.

--- a/docs/draft-schema/02-materials.md
+++ b/docs/draft-schema/02-materials.md
@@ -46,6 +46,21 @@ CapCut stores still images in the same array as video clips. The discriminator i
 }
 ```
 
+**`matting` — smart matting / "Remove background" / 智能抠像 (v0.22).** The
+object above is the OFF state every app-authored video material carries.
+`capcut matting <project> <segment-id>` writes `flag: 3` — "smart portrait
+matting" — and leaves the cache fields at their empty defaults; the app fills
+`path` (its matting cache) and the brush/eraser corrections itself on first
+open. `--off` writes `flag: 0` back and keeps whatever cache fields are there
+(never deletes the key). Provenance: the on-state encoding comes from the
+pyJianYingDraft contributor PRs [#183](https://github.com/GuanYixuan/pyJianYingDraft/pull/183)
+/ [#184](https://github.com/GuanYixuan/pyJianYingDraft/pull/184) (KyonXuan,
+2026-05, unmerged), which also add `has_use_quick_eraser` on newer builds — the
+CLI writes it alongside the brush flag. No app-authored flag-3 material is
+committed here yet; `capcut fixture` on a draft where the app did the cutout
+would confirm the shape. Matting is per MATERIAL: segments sharing one material
+(the command reports them as `shared_segments`) change together.
+
 For images: `type: "photo"`, `duration: 10800000000` (3 hours, conventionally), and `width/height` reflect the image dimensions.
 
 Files added via `add-video` / `add-audio` are copied into `<draft>/assets/<kind>/` and the material's `path` is set to a relative or absolute path that CapCut can resolve.

--- a/docs/draft-schema/03-keyframes-and-animations.md
+++ b/docs/draft-schema/03-keyframes-and-animations.md
@@ -56,6 +56,14 @@ One entry per property. Within an entry, `keyframe_list` is sorted by `time_offs
 > A test now fails if this table and `PROPERTY_MAP` disagree again, so the two
 > cannot drift apart silently a second time.
 
+**Aliases (v0.22).** The IR-style names agent pipelines use are accepted
+wherever a property is read (`keyframe`, `keyframe --batch`, compile's keyframe
+op) and stored under the canonical name above — `scale` → `uniform_scale`,
+`x` → `position_x`, `y` → `position_y`, `opacity` → `alpha`. `scale` always
+means the uniform scale (the IR meaning), never `scale_x`/`scale_y`. Every
+downstream integrator had been re-implementing this table by hand (vertir's
+PROP_MAP, qcut's spec.py).
+
 The `keyframe` CLI command appends to existing per-property lists on re-invocation and sorts by `time_offset`, so you can build up complex motion incrementally.
 
 ### `curveType`
@@ -63,7 +71,14 @@ The `keyframe` CLI command appends to existing per-property lists on re-invocati
 Per-keyframe interpolation curve to the NEXT keyframe in the list:
 
 - `"Line"` — linear (default)
-- `"Hold"` — step (no interpolation)
+- `"Hold"` — step (no interpolation). **Listed, not verified:** no app-authored
+  draft in this repo or the neighbouring ecosystem carries it, so `capcut-cli`
+  never writes it — an unverified encoding would save without error and could
+  silently no-op. `keyframe --easing hold` (v0.22) emulates the step with plain
+  `"Line"` keyframes instead: a helper keyframe carrying the held value one
+  frame before the NEXT keyframe on that property, so the whole ramp happens
+  inside a single frame. A fixture that shows the app writing `"Hold"` would
+  let the flag switch to the native curve.
 - `"Smooth"` — ease in/out
 - `"Beizer"` — custom bezier (additional `value_bezier_control_points` field)
 - `"FreeCurveInOut"` — bezier via `left_control` / `right_control` handles; this is what the CapCut UI writes when an easing preset (Cubic In / Cubic Out / …) is applied

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capcut-cli",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capcut-cli",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "license": "MIT",
       "bin": {
         "capcut": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capcut-cli",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Independent, unofficial CLI to create and edit CapCut projects — build drafts from scratch, add video/audio/text, subtitles, timing, speed, volume, templates, cut long-form to shorts. No API needed. Not affiliated with ByteDance.",
   "type": "module",
   "bin": {

--- a/src/align.ts
+++ b/src/align.ts
@@ -1,0 +1,281 @@
+// Transcript-guided caption alignment (`caption --script`).
+//
+// Whisper hears the audio; the author already knows what was said. Names,
+// product terms, numbers and punctuation are exactly what speech recognition
+// gets wrong most often — and the pipelines that most want burned-in captions
+// (talking-head shorts, narrated explainers, dubbed courses) usually have the
+// script on hand (neo9su/autoclipvideo#174, baizhiheizi/enjoy_player#540 both
+// ask for word timing on a KNOWN text rather than a fresh transcription).
+// This module keeps whisper's timing and swaps in the script's wording:
+//
+//   1. tokenise both sides and compare on a normalised form (lower-case, NFKC,
+//      punctuation stripped) so "Ramaris," and "ramaris" match;
+//   2. globally align the two token sequences (Needleman–Wunsch: match +2,
+//      near-miss substitution +1, other substitution −1, gap −1 — the classic
+//      transcript-alignment scoring, with the near-miss term so a mis-heard
+//      word pairs with the word it was, not with a neighbour);
+//   3. every script word aligned to a recognised word inherits that word's
+//      start/end; script words whisper missed are spread evenly across the gap
+//      between their timed neighbours (or extrapolated at the edges at the
+//      recognised words' median duration).
+//
+// The alignment is pure and deterministic, so tests assert it without whisper;
+// the caller decides how the timed script words become cues (script lines are
+// the natural cue boundaries — an author who pre-chunks the script controls
+// exactly where the captions break).
+
+import type { CaptionWord } from "./caption.js";
+
+export interface AlignedWord extends CaptionWord {
+  /** True when this script word was aligned to an identical recognised word. */
+  matched: boolean;
+  /** Which script line (0-based) the word came from — the cue boundary hint. */
+  line: number;
+}
+
+export interface AlignmentReport {
+  script_words: number;
+  recognized_words: number;
+  /** Script words aligned to an identical recognised token. */
+  matched: number;
+  /** Script words aligned to a DIFFERENT recognised token (whisper mis-heard). */
+  substituted: number;
+  /** Script words whisper produced nothing for (timing interpolated). */
+  inserted: number;
+  /** Recognised words the script does not contain (ignored). */
+  dropped: number;
+  /** matched / script_words — below ~0.5 the script probably does not belong to this audio. */
+  match_ratio: number;
+}
+
+/** Comparison form of a token: NFKC, lower-case, letters/digits only (any script). */
+export function normalizeToken(token: string): string {
+  return token
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+/**
+ * Script text → lines → words. Blank lines are dropped; a line is a unit the
+ * caller may keep together as one cue. Tokens with no letters or digits
+ * (a lone "—", "...") cannot be aligned or spoken and are removed.
+ */
+export function tokenizeScript(text: string): string[][] {
+  const lines: string[][] = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const words = rawLine
+      .trim()
+      .split(/\s+/)
+      .filter((w) => w.length > 0 && normalizeToken(w).length > 0);
+    if (words.length > 0) lines.push(words);
+  }
+  return lines;
+}
+
+const MATCH = 2;
+const NEAR_MATCH = 1;
+const MISMATCH = -1;
+const GAP = -1;
+
+/** Levenshtein distance, only ever called for short, similarly-sized tokens. */
+function editDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  let prev = new Uint16Array(cols);
+  let cur = new Uint16Array(cols);
+  for (let j = 0; j < cols; j++) prev[j] = j;
+  for (let i = 1; i < rows; i++) {
+    cur[0] = i;
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[cols - 1];
+}
+
+/**
+ * Substitution score for two different normalised tokens. A recogniser's
+ * mistakes are usually NEAR misses ("chanel"/"channel", "ramarys"/"ramaris"),
+ * so a pair within roughly 40% edit distance scores positive — that is what
+ * makes the alignment prefer "ramaris ↔ ramarys" over pairing the recognised
+ * word with whatever unrelated script word happens to sit next to it when the
+ * plain mismatch scores tie. Cheap length/character prefilters keep the
+ * Levenshtein call rare on a long transcript.
+ */
+function substitutionScore(a: string, b: string): number {
+  if (a === b) return MATCH;
+  const longest = Math.max(a.length, b.length);
+  if (longest < 3 || Math.abs(a.length - b.length) > 2) return MISMATCH;
+  if (a[0] !== b[0] && a[a.length - 1] !== b[b.length - 1]) return MISMATCH;
+  return editDistance(a, b) / longest <= 0.4 ? NEAR_MATCH : MISMATCH;
+}
+
+/**
+ * Needleman–Wunsch over the normalised tokens. Returns, per script word, the
+ * index of the recognised word it aligned to (or -1), plus whether that pair
+ * is an exact match. Typed arrays keep a 5k × 5k alignment (an hour of speech)
+ * in the tens of megabytes and well under a second.
+ */
+function alignTokens(script: string[], recognized: string[]): { pair: Int32Array; exact: Uint8Array } {
+  const n = script.length;
+  const m = recognized.length;
+  const cols = m + 1;
+  const score = new Int32Array((n + 1) * cols);
+  // 0 = diagonal, 1 = up (script gap: word inserted), 2 = left (recognised dropped)
+  const move = new Uint8Array((n + 1) * cols);
+  for (let i = 1; i <= n; i++) {
+    score[i * cols] = i * GAP;
+    move[i * cols] = 1;
+  }
+  for (let j = 1; j <= m; j++) {
+    score[j] = j * GAP;
+    move[j] = 2;
+  }
+  for (let i = 1; i <= n; i++) {
+    const s = script[i - 1];
+    for (let j = 1; j <= m; j++) {
+      const diag = score[(i - 1) * cols + (j - 1)] + substitutionScore(s, recognized[j - 1]);
+      const up = score[(i - 1) * cols + j] + GAP;
+      const left = score[i * cols + (j - 1)] + GAP;
+      let best = diag;
+      let via = 0;
+      if (up > best) {
+        best = up;
+        via = 1;
+      }
+      if (left > best) {
+        best = left;
+        via = 2;
+      }
+      score[i * cols + j] = best;
+      move[i * cols + j] = via;
+    }
+  }
+  const pair = new Int32Array(n).fill(-1);
+  const exact = new Uint8Array(n);
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    const via = i === 0 ? 2 : j === 0 ? 1 : move[i * cols + j];
+    if (via === 0) {
+      pair[i - 1] = j - 1;
+      exact[i - 1] = script[i - 1] === recognized[j - 1] ? 1 : 0;
+      i--;
+      j--;
+    } else if (via === 1) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  return { pair, exact };
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+/** Fallback word length when the recogniser produced no word timings at all. */
+export const DEFAULT_WORD_DURATION_US = 300_000;
+
+/**
+ * Time the script against the recognised words. Every script word gets a
+ * start/end; the report says how well the two sides agreed.
+ */
+export function alignScript(
+  scriptLines: string[][],
+  recognized: CaptionWord[],
+): { words: AlignedWord[]; lines: AlignedWord[][]; report: AlignmentReport } {
+  const flat: Array<{ word: string; line: number }> = [];
+  scriptLines.forEach((line, index) => {
+    for (const word of line) flat.push({ word, line: index });
+  });
+  const scriptNorm = flat.map((w) => normalizeToken(w.word));
+  const recognizedNorm = recognized.map((w) => normalizeToken(w.word));
+  const { pair, exact } = alignTokens(scriptNorm, recognizedNorm);
+
+  const words: AlignedWord[] = flat.map((w, i) => {
+    const r = pair[i] >= 0 ? recognized[pair[i]] : null;
+    return {
+      word: w.word,
+      line: w.line,
+      matched: exact[i] === 1,
+      startUs: r ? r.startUs : Number.NaN,
+      endUs: r ? r.endUs : Number.NaN,
+    };
+  });
+
+  // Interpolate the untimed runs between their timed neighbours.
+  const durations = recognized.map((w) => Math.max(1, w.endUs - w.startUs));
+  const typical = median(durations) || DEFAULT_WORD_DURATION_US;
+  let i = 0;
+  while (i < words.length) {
+    if (!Number.isNaN(words[i].startUs)) {
+      i++;
+      continue;
+    }
+    let end = i;
+    while (end < words.length && Number.isNaN(words[end].startUs)) end++;
+    const run = end - i; // words[i..end) untimed
+    const prev = i > 0 ? words[i - 1] : null;
+    const next = end < words.length ? words[end] : null;
+    let spanStart: number;
+    let spanEnd: number;
+    if (prev && next) {
+      spanStart = prev.endUs;
+      spanEnd = Math.max(next.startUs, spanStart + run); // never zero-length
+    } else if (prev) {
+      spanStart = prev.endUs;
+      spanEnd = spanStart + run * typical;
+    } else if (next) {
+      spanEnd = next.startUs;
+      spanStart = Math.max(0, spanEnd - run * typical);
+    } else {
+      spanStart = 0;
+      spanEnd = run * typical;
+    }
+    const slot = (spanEnd - spanStart) / run;
+    for (let k = 0; k < run; k++) {
+      words[i + k].startUs = Math.round(spanStart + slot * k);
+      words[i + k].endUs = Math.round(spanStart + slot * (k + 1));
+    }
+    i = end;
+  }
+  // Timing must stay monotonic even when the recogniser's words overlap slightly.
+  for (let k = 1; k < words.length; k++) {
+    if (words[k].startUs < words[k - 1].endUs) words[k].startUs = words[k - 1].endUs;
+    if (words[k].endUs <= words[k].startUs) words[k].endUs = words[k].startUs + 1;
+  }
+
+  const lines: AlignedWord[][] = scriptLines.map(() => []);
+  for (const w of words) lines[w.line].push(w);
+
+  let matched = 0;
+  let substituted = 0;
+  let inserted = 0;
+  const usedRecognized = new Set<number>();
+  for (let k = 0; k < words.length; k++) {
+    if (pair[k] < 0) inserted++;
+    else {
+      usedRecognized.add(pair[k]);
+      if (exact[k] === 1) matched++;
+      else substituted++;
+    }
+  }
+  const report: AlignmentReport = {
+    script_words: words.length,
+    recognized_words: recognized.length,
+    matched,
+    substituted,
+    inserted,
+    dropped: recognized.length - usedRecognized.size,
+    match_ratio: words.length === 0 ? 0 : Math.round((matched / words.length) * 1000) / 1000,
+  };
+  return { words, lines, report };
+}

--- a/src/caption.ts
+++ b/src/caption.ts
@@ -3,6 +3,7 @@ import { randomUUID as uuid } from "node:crypto";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { type AlignmentReport, alignScript, tokenizeScript } from "./align.js";
 import {
   buildEmphasisRanges,
   DEFAULT_KEYWORD_SIZE,
@@ -34,6 +35,12 @@ export interface CaptionOptions {
   keywordColor?: string; // emphasis colour; default KARAOKE_HIGHLIGHT_COLOR
   keywordSize?: number; // emphasis multiplier on the cue's base font size; default DEFAULT_KEYWORD_SIZE
   colorCycle?: string[]; // rotate the BASE text colour per cue in list order
+  /**
+   * --script: the known transcript. Whisper's word timing is kept, the
+   * script's wording is used (see align.ts); each non-empty script line is a
+   * cue boundary, long lines still split at --max-chars.
+   */
+  scriptText?: string;
 }
 
 export interface CaptionWord {
@@ -63,6 +70,8 @@ export interface CaptionResult {
   karaoke?: boolean;
   keyword_matches?: number;
   color_cycle?: number;
+  /** --script alignment quality (only when a script was given). */
+  script?: AlignmentReport;
 }
 
 /**
@@ -85,14 +94,29 @@ export function captionDraft(draft: Draft, opts: CaptionOptions): CaptionResult 
   }
   const audio = resolveAudio(draft, opts);
   const transcription = runWhisper(audio, opts);
-  const cues = opts.karaoke
-    ? groupWords(
-        transcription.words.length > 0 ? transcription.words : wordsFromCues(transcription.cues),
-        opts.maxWords ?? 4,
-        opts.maxChars ?? 28,
-        (opts.maxGapMs ?? 500) * 1000,
-      )
-    : transcription.cues;
+  const recognizedWords = transcription.words.length > 0 ? transcription.words : wordsFromCues(transcription.cues);
+  let scriptReport: AlignmentReport | undefined;
+  let cues: CaptionCue[];
+  if (opts.scriptText !== undefined) {
+    const lines = tokenizeScript(opts.scriptText);
+    if (lines.length === 0) throw new Error("--script file contains no words.");
+    if (recognizedWords.length === 0) {
+      throw new Error("Whisper produced no words to align the script to. Check the audio is not silent.");
+    }
+    const aligned = alignScript(lines, recognizedWords);
+    scriptReport = aligned.report;
+    cues = opts.karaoke
+      ? groupWords(aligned.words, opts.maxWords ?? 4, opts.maxChars ?? 28, (opts.maxGapMs ?? 500) * 1000)
+      : // One cue per script line — the author's chunking — split only when a
+        // line outgrows --max-chars (words and gaps never split a line).
+        aligned.lines.flatMap((line) =>
+          groupWords(line, Number.POSITIVE_INFINITY, opts.maxChars ?? 42, Number.POSITIVE_INFINITY),
+        );
+  } else {
+    cues = opts.karaoke
+      ? groupWords(recognizedWords, opts.maxWords ?? 4, opts.maxChars ?? 28, (opts.maxGapMs ?? 500) * 1000)
+      : transcription.cues;
+  }
   if (cues.length === 0) {
     throw new Error("Whisper produced no cues. Check the audio file is not silent and the model name is valid.");
   }
@@ -193,6 +217,7 @@ export function captionDraft(draft: Draft, opts: CaptionOptions): CaptionResult 
     // undefined when the flags are off, so JSON output stays byte-identical.
     keyword_matches: highlightWords.length > 0 ? keywordMatches : undefined,
     color_cycle: colorCycle.length > 0 ? colorCycle.length : undefined,
+    script: scriptReport,
   };
 }
 

--- a/src/command-specs.ts
+++ b/src/command-specs.ts
@@ -131,6 +131,20 @@ const TEXT_STYLE: OptionSpec[] = [
   option("bg_v_offset", ["--bg-v-offset"], "number", "Background vertical offset."),
 ];
 
+// Canvas at creation (init / quickstart): a preset picks CapCut's native size
+// for that aspect; explicit width+height set an exact canvas (both or neither).
+const CANVAS: OptionSpec[] = [
+  option(
+    "ratio",
+    ["--ratio"],
+    "enum",
+    "Canvas aspect preset at the size CapCut uses for it (16:9 = 1920x1080, the template default; 9:16 = 1080x1920 portrait). Explicit --width/--height win over the preset's size but keep its label.",
+    { values: ["16:9", "9:16", "1:1", "4:3", "3:4"] },
+  ),
+  option("width", ["--width"], "number", "Exact canvas width in pixels (requires --height)."),
+  option("height", ["--height"], "number", "Exact canvas height in pixels (requires --width)."),
+];
+
 const KEYWORD_EMPHASIS: OptionSpec[] = [
   option(
     "color_cycle",
@@ -172,7 +186,7 @@ const usages = {
   opacity: "capcut opacity <project> <id> <alpha>",
   "export-srt": "capcut export-srt <project> [options]",
   "export-ass": "capcut export-ass <project> [--karaoke] [--out <file.ass>]",
-  "export-timeline": "capcut export-timeline <project> [--out <file.otio>]",
+  "export-timeline": "capcut export-timeline <project> [--out <file.otio>] [--captions skip|markers]",
   "import-timeline": "capcut import-timeline <file.otio> (--out <new-project> | --into <project>)",
   materials: "capcut materials <project> [--type <type>]",
   segment: "capcut segment <project> <id>",
@@ -211,8 +225,9 @@ const usages = {
   migrate: "capcut migrate <project> --from <version> --to <version>",
   "add-sfx": "capcut add-sfx <project> <slug> <start> <duration> [options]",
   chroma: "capcut chroma <project> <id> (--color <hex> | --off) [options]",
+  matting: "capcut matting <project> <id> [--off]",
   prune: "capcut prune <project>",
-  register: "capcut register <project-dir> [--apply] [--drafts <dir>]",
+  register: "capcut register <project-dir> [--apply] [--materials] [--drafts <dir>]",
   rename: "capcut rename <project> <new-name> [--drafts <dir>]",
   relink: "capcut relink <project> (--dir <path> | --from <prefix> --to <prefix>) [--stage]",
   timeline: "capcut timeline <project> [--cols <number>]",
@@ -235,12 +250,15 @@ const usages = {
   decrypt: "capcut decrypt <project-or-file>",
   export: "capcut export <drafts-dir> --batch [options]",
   "replace-media": "capcut replace-media <project> <segment-id> <new-file> [--retime]",
-  init: "capcut init <name> [--template <dir>] [--drafts <dir>]",
-  quickstart: "capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>]",
+  init: "capcut init <name> [--template <dir>] [--drafts <dir>] [--ratio <r> | --width <px> --height <px>]",
+  quickstart:
+    "capcut quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>] [--ratio <r> | --width <px> --height <px>]",
   compile: "capcut compile <spec.json> [--out <draftdir>] [--data <rows.jsonl|->] [--check | --plan]",
   render: "capcut render <project> [--out <preview.mp4>] [options]",
   "detect-scenes": "capcut detect-scenes <video> [options]",
   "detect-silence": "capcut detect-silence <media> [options]",
+  "detect-retakes":
+    "capcut detect-retakes <project> [--track-name <s>] [--window <s>] [--similarity <n>] [--min-words <n>] | --srt <file>",
 } as const satisfies Record<string, string>;
 
 export type CommandName = keyof typeof usages;
@@ -342,9 +360,9 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
       "easing",
       ["--easing"],
       "enum",
-      "Interpolation easing to adjacent keyframes. Needs an adjacent keyframe on the same property; a lone eased keyframe stays linear (warns).",
+      "Interpolation easing to adjacent keyframes. Needs an adjacent keyframe on the same property; a lone eased keyframe stays linear (warns). hold = step: the value is held by a helper keyframe one frame before the next keyframe on that property (needs a later keyframe; warns otherwise).",
       {
-        values: ["linear", "ease-in", "ease-out", "ease-in-out"],
+        values: ["linear", "ease-in", "ease-out", "ease-in-out", "hold"],
         default: "linear",
       },
     ),
@@ -451,7 +469,16 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
     ),
     OUT,
   ],
-  "export-timeline": [OUT],
+  "export-timeline": [
+    OUT,
+    option(
+      "captions",
+      ["--captions"],
+      "enum",
+      "Text/caption tracks: skip them with a note (default), or write every cue as an OTIO timeline marker on the Stack (name = text, marked_range = timing, metadata.capcut.kind = caption) — Resolve/Premiere import those as timeline markers and import-timeline rebuilds the text track from them.",
+      { values: ["skip", "markers"], default: "skip" },
+    ),
+  ],
   "import-timeline": [
     option("out", ["--out"], "path", "Build a NEW draft directory at this path from the OTIO timeline."),
     option(
@@ -479,6 +506,12 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
   ],
   "text-ranges": [option("styles", ["--styles"], "json", "Inline JSON or @file style ranges.")],
   caption: [
+    option(
+      "script",
+      ["--script"],
+      "path",
+      "Known transcript (plain text). Whisper's word timing is kept, the script's wording is used; each non-empty line is a cue boundary. The result's `script` block reports matched/substituted/inserted words.",
+    ),
     option("audio", ["--audio"], "path", "Audio input."),
     option("from_segment", ["--from-segment"], "id", "Audio segment input."),
     option("whisper_cmd", ["--whisper-cmd"], "path", "Whisper binary."),
@@ -512,12 +545,26 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
     option("intensity", ["--intensity"], "number", "Key intensity."),
     option("off", ["--off"], "boolean", "Remove chroma key."),
   ],
+  matting: [
+    option(
+      "off",
+      ["--off"],
+      "boolean",
+      "Turn smart matting off: writes the documented flag-0 matting object on the segment's video material (cache fields kept).",
+    ),
+  ],
   register: [
     option(
       "apply",
       ["--apply"],
       "boolean",
       "Write the repaired draft_meta_info.json / root_meta_info.json entry (default: print the plan only).",
+    ),
+    option(
+      "materials",
+      ["--materials"],
+      "boolean",
+      "Also register the timeline's local media in draft_meta_info.json's draft_materials (the list CapCut 9.1 uses to decide what is imported; empty, every clip shows as 'file inaccessible'). Appends missing entries to the type-0 group, preserves existing ones, no-ops when complete.",
     ),
     option("drafts", ["--drafts"], "path", "Draft store root when the draft does not live inside a known one."),
   ],
@@ -633,6 +680,7 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
   init: [
     option("template", ["--template"], "path", "Template directory."),
     option("drafts", ["--drafts"], "path", "Draft root directory."),
+    ...CANVAS,
   ],
   quickstart: [
     option("video", ["--video"], "path", "Video or image to add."),
@@ -641,6 +689,7 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
     option("drafts", ["--drafts"], "path", "Draft root directory."),
     option("template", ["--template"], "path", "Template directory."),
     option("ffprobe_cmd", ["--ffprobe-cmd"], "path", "ffprobe binary for duration detection."),
+    ...CANVAS,
   ],
   compile: [
     OUT,
@@ -673,6 +722,12 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
       "Video encoder for the proxy (-c:v; default libx264). Hardware encoders like h264_videotoolbox/h264_nvenc/h264_qsv work when the build carries them; validated against `ffmpeg -encoders` before rendering.",
     ),
     option("burn_captions", ["--burn-captions"], "boolean", "Burn captions."),
+    option(
+      "soft_captions",
+      ["--soft-captions"],
+      "boolean",
+      "Mux the text-track cues as a toggleable mov_text subtitle stream (the SRT is also written next to the output as <preview>.srt); skipped with a note when ffmpeg has no mov_text encoder.",
+    ),
     option("all_video_tracks", ["--all-video-tracks"], "boolean", "Composite every video track."),
     option("progress", ["--progress"], "boolean", "Stream ffmpeg's progress to stderr instead of buffering it."),
   ],
@@ -717,6 +772,20 @@ const optionsByCommand: Record<string, OptionSpec[]> = {
     ),
     option("json", ["--json"], "boolean", "Force JSON output (the default; overrides -H)."),
   ],
+  "detect-retakes": [
+    TRACK_NAME,
+    option("srt", ["--srt"], "path", "Read cues from this SRT file instead of a draft (no <project> then)."),
+    option("window", ["--window"], "number", "Max seconds between the earlier cue's end and the later cue's start.", {
+      default: 60,
+    }),
+    option("similarity", ["--similarity"], "number", "Word-sequence similarity floor, 0..1 (2·LCS/(a+b)).", {
+      default: 0.8,
+    }),
+    option("min_words", ["--min-words"], "number", "Cues with fewer normalised words never count as a take.", {
+      default: 4,
+    }),
+    option("json", ["--json"], "boolean", "Force JSON output (the default; overrides -H)."),
+  ],
 };
 optionsByCommand["image-anim"] = optionsByCommand["text-anim"];
 
@@ -728,7 +797,7 @@ optionsByCommand["image-anim"] = optionsByCommand["text-anim"];
 //   --granularity, --format -> export-srt
 //   --preset            -> add-text, text-style, caption
 //   --apply             -> register, sync-timelines
-//   --ratio, --rect, --reset -> crop
+//   --ratio, --rect, --reset -> crop; --ratio also -> init, quickstart (v0.22 canvas preset)
 //   --threshold, --min-gap, --limit, --json -> detect-scenes
 //   --highlight-words, --keyword-color, --keyword-size, --color-cycle
 //                       -> caption, import-srt (v0.14 keyword emphasis)
@@ -749,12 +818,18 @@ optionsByCommand["image-anim"] = optionsByCommand["text-anim"];
 //   --kind               -> catalogue (v0.21 cross-category lookup); --limit also scopes there
 //   --clone-style        -> import-srt, import-ass (v0.21 id-free style preservation)
 //   --stage              -> relink (v0.21 stage relinked media into the draft)
+//   --materials          -> register (v0.22 draft_materials registration)
+//   --captions           -> export-timeline (v0.22 caption cues as OTIO timeline markers)
+//   --script             -> caption (v0.22 transcript-guided alignment)
+//   --window, --similarity, --min-words -> detect-retakes (v0.22); --json also scopes there
+//   --soft-captions      -> render (v0.22 mov_text subtitle stream)
 // Everywhere else they fall through to the positional stream verbatim, matching
 // pre-release behaviour where these tokens were unknown and preserved.
 export const RELEASE_SCOPED_FLAGS: ReadonlySet<string> = new Set([
   "--add",
   "--apply",
   "--bind",
+  "--captions",
   "--catalogue",
   "--clone-style",
   "--color-cycle",
@@ -774,8 +849,10 @@ export const RELEASE_SCOPED_FLAGS: ReadonlySet<string> = new Set([
   "--kind",
   "--limit",
   "--mask-field",
+  "--materials",
   "--min-gap",
   "--min-silence",
+  "--min-words",
   "--nested",
   "--new-track",
   "--pad",
@@ -785,12 +862,16 @@ export const RELEASE_SCOPED_FLAGS: ReadonlySet<string> = new Set([
   "--ratio",
   "--rect",
   "--reset",
+  "--script",
+  "--similarity",
+  "--soft-captions",
   "--sync",
   "--text",
   "--text-file",
   "--threshold",
   "--threshold-db",
   "--tts-cmd",
+  "--window",
 ]);
 
 /** True when `command` declares `flag` among its command-specific options. */
@@ -841,6 +922,7 @@ const mutating = new Set([
   "migrate",
   "add-sfx",
   "chroma",
+  "matting",
   "prune",
   "register",
   "rename",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -23,6 +23,38 @@ export function keyframeProperties(): string[] {
   return Object.keys(PROPERTY_MAP);
 }
 
+// IR-style property names. Every downstream integrator that drives keyframes
+// from its own intermediate representation ends up re-implementing the same
+// four-line translation table (vertir's PROP_MAP, qcut's spec.py: scale →
+// uniform_scale, x/y → position_x/y, opacity → alpha). Accept the aliases
+// wherever a property name is read — `keyframe`, `keyframe --batch`, compile's
+// keyframe op — and store under the canonical name, so `lists`, `describe` and
+// the on-disk property_type stay unambiguous. `scale` deliberately means the
+// UNIFORM scale (the IR meaning), never scale_x/scale_y.
+const PROPERTY_ALIASES: Record<string, string> = {
+  scale: "uniform_scale",
+  x: "position_x",
+  y: "position_y",
+  opacity: "alpha",
+};
+
+export function keyframePropertyAliases(): Record<string, string> {
+  return { ...PROPERTY_ALIASES };
+}
+
+/** Canonical property name for `name`, resolving aliases; throws on anything else. */
+export function resolveKeyframeProperty(name: string): string {
+  const key = String(name).trim();
+  if (Object.hasOwn(PROPERTY_MAP, key)) return key;
+  if (Object.hasOwn(PROPERTY_ALIASES, key)) return PROPERTY_ALIASES[key];
+  const aliases = Object.entries(PROPERTY_ALIASES)
+    .map(([alias, canonical]) => `${alias}=${canonical}`)
+    .join(", ");
+  throw new Error(
+    `Unsupported keyframe property: ${name}. Supported: ${Object.keys(PROPERTY_MAP).join(", ")} (aliases: ${aliases})`,
+  );
+}
+
 /**
  * The on-disk `property_type` identifiers the keyframe machinery knows how to
  * write. Used by the `fixture` mask-keyframe harvest (#44) to split the
@@ -43,14 +75,23 @@ export function keyframePropertyTypes(): string[] {
 // test-fixtures/oracles/cubic-out-triplet-frame-aligned.json): control.x
 // matches CapCut exactly on frame-aligned intervals and within ±1μs otherwise;
 // control.y within 1 ULP.
-export type EasingName = "linear" | "ease-in" | "ease-out" | "ease-in-out";
+//
+// "hold" is not a CapCut curve at all: the app always interpolates between two
+// keyframes, so a step (keep this value, then jump at the next keyframe) has no
+// native encoding — downstream IRs that carry one (qcut's EASE_MAP, vertir)
+// used to degrade it to linear and get a ramp the author never asked for. The
+// step is emulated the way an editor does it by hand: a helper keyframe one
+// frame before the NEXT keyframe, carrying the held value, so the whole ramp
+// happens inside a single frame. See applyHolds.
+export type EasingName = "linear" | "ease-in" | "ease-out" | "ease-in-out" | "hold";
+type CurveEasing = Exclude<EasingName, "linear" | "hold">;
 
 interface EasingProfile {
   startRightXRatio: number; // × interval → segment-start keyframe's right_control.x
   endLeftXRatio: number; // × interval → segment-end keyframe's left_control.x
 }
 
-const EASING_PROFILES: Record<Exclude<EasingName, "linear">, EasingProfile> = {
+const EASING_PROFILES: Record<CurveEasing, EasingProfile> = {
   "ease-in": { startRightXRatio: 0.42, endLeftXRatio: 0 },
   "ease-out": { startRightXRatio: 0.32, endLeftXRatio: -0.4 },
   "ease-in-out": { startRightXRatio: 0.42, endLeftXRatio: -0.42 },
@@ -62,7 +103,7 @@ const EASING_PROFILES: Record<Exclude<EasingName, "linear">, EasingProfile> = {
 const EASE_OUT_RIGHT_Y_RATIO = 0.94;
 
 export function keyframeEasings(): string[] {
-  return ["linear", ...Object.keys(EASING_PROFILES)];
+  return ["linear", ...Object.keys(EASING_PROFILES), "hold"];
 }
 
 // Exported so compile's spec validation pre-flights the exact same check
@@ -72,16 +113,14 @@ export function keyframeEasings(): string[] {
 // an inherited function whose ratios are undefined and NaN-corrupt the draft.
 export function resolveEasing(easing: string | undefined): EasingName {
   if (easing === undefined) return "linear";
-  if (easing !== "linear" && !Object.hasOwn(EASING_PROFILES, easing)) {
+  if (easing !== "linear" && easing !== "hold" && !Object.hasOwn(EASING_PROFILES, easing)) {
     throw new Error(`Unsupported keyframe easing: ${easing}. Supported: ${keyframeEasings().join(", ")}`);
   }
   return easing as EasingName;
 }
 
-export function parseKeyframeValue(property: string, value: string): number {
-  if (!Object.hasOwn(PROPERTY_MAP, property)) {
-    throw new Error(`Unsupported keyframe property: ${property}. Supported: ${Object.keys(PROPERTY_MAP).join(", ")}`);
-  }
+export function parseKeyframeValue(propertyOrAlias: string, value: string): number {
+  const property = resolveKeyframeProperty(propertyOrAlias);
   const v = value.trim();
   if (property === "position_x" || property === "position_y") {
     const n = parseFloat(v);
@@ -202,7 +241,7 @@ function clearFacingHandles(list: KeyframeEntry[], timeOffset: number): void {
 // stamping FreeCurveInOut with zero-length handles would write a curve-type
 // marker its handles contradict. The stamp happens later instead, when the
 // pair's second keyframe is inserted with an easing and retro-updates this one.
-function applyEasing(list: KeyframeEntry[], entry: KeyframeEntry, easing: Exclude<EasingName, "linear">): boolean {
+function applyEasing(list: KeyframeEntry[], entry: KeyframeEntry, easing: CurveEasing): boolean {
   const profile = EASING_PROFILES[easing];
   const rightY = (fromValue: number, toValue: number): number =>
     easing === "ease-out" ? Math.round(EASE_OUT_RIGHT_Y_RATIO * (toValue - fromValue) * 1e6) / 1e6 : 0;
@@ -231,12 +270,69 @@ function applyEasing(list: KeyframeEntry[], entry: KeyframeEntry, easing: Exclud
   return true;
 }
 
+/**
+ * Emulate `hold` after every requested keyframe is in place (so a batch may
+ * name the held keyframe before the one it holds until): for each held entry,
+ * insert a helper keyframe carrying the same value one frame before the next
+ * keyframe on that property. The app then interpolates the whole change inside
+ * one frame — a step, as far as any viewer can tell. A hold with no later
+ * keyframe, or one whose neighbour is already within a frame, has nothing to
+ * hold until and is reported as a warning instead of inventing a keyframe.
+ */
+function applyHolds(
+  holds: Array<{ list: KeyframeListObject; entry: KeyframeEntry; property: string }>,
+  fps: number,
+  warnings: string[],
+): number {
+  const frameUs = Math.round(1_000_000 / fps);
+  let inserted = 0;
+  for (const { list, entry, property } of holds) {
+    const { next } = findNeighbours(list.keyframe_list, entry.time_offset);
+    if (!next) {
+      warnings.push(
+        `hold for ${property} at ${entry.time_offset}us has no later keyframe to hold until; wrote a plain keyframe`,
+      );
+      continue;
+    }
+    // A next keyframe that already carries the held value IS the hold (this is
+    // also what a previous run's helper looks like) — nothing to add.
+    if (next.values.length === entry.values.length && next.values.every((v, k) => v === entry.values[k])) continue;
+    const holdAt = next.time_offset - frameUs;
+    if (holdAt <= entry.time_offset) {
+      warnings.push(
+        `hold for ${property} at ${entry.time_offset}us: the next keyframe is within one frame, nothing to hold`,
+      );
+      continue;
+    }
+    if (list.keyframe_list.some((k) => k.time_offset === holdAt)) continue; // already stepped
+    list.keyframe_list.push({
+      curveType: "Line",
+      graphID: "",
+      left_control: { x: 0.0, y: 0.0 },
+      right_control: { x: 0.0, y: 0.0 },
+      id: uuidHex(),
+      time_offset: holdAt,
+      values: [...entry.values],
+    });
+    list.keyframe_list.sort((a, b) => a.time_offset - b.time_offset);
+    inserted++;
+  }
+  return inserted;
+}
+
 export function addKeyframes(
   draft: Draft,
   segmentId: string,
   keyframes: KeyframeInput[],
   easing?: string,
-): { segmentId: string; added: number; lists: Array<{ property: string; count: number }>; warnings: string[] } {
+): {
+  segmentId: string;
+  added: number;
+  lists: Array<{ property: string; count: number }>;
+  warnings: string[];
+  /** Helper keyframes written to emulate `hold` (0 when no hold was requested). */
+  holdKeyframes: number;
+} {
   resolveEasing(easing); // fail fast even when every keyframe overrides it
   const found = findSegment(draft, segmentId);
   if (!found) throw new Error(`Segment not found: ${segmentId}`);
@@ -247,14 +343,11 @@ export function addKeyframes(
   }
   const commonKeyframes = seg.common_keyframes as KeyframeListObject[];
   const warnings: string[] = [];
+  const holds: Array<{ list: KeyframeListObject; entry: KeyframeEntry; property: string }> = [];
 
   for (const kf of keyframes) {
-    const propEnum = Object.hasOwn(PROPERTY_MAP, kf.property) ? PROPERTY_MAP[kf.property] : undefined;
-    if (!propEnum) {
-      throw new Error(
-        `Unsupported keyframe property: ${kf.property}. Supported: ${Object.keys(PROPERTY_MAP).join(", ")}`,
-      );
-    }
+    const property = resolveKeyframeProperty(kf.property);
+    const propEnum = PROPERTY_MAP[property];
     const kfEasing = resolveEasing(kf.easing ?? easing);
     let list = commonKeyframes.find((l) => l.property_type === propEnum);
     if (!list) {
@@ -275,7 +368,12 @@ export function addKeyframes(
       time_offset: kf.timeUs,
       values: [kf.value],
     };
-    if (kfEasing !== "linear") {
+    if (kfEasing === "hold") {
+      // A held keyframe is a plain linear one; the step is added by applyHolds
+      // once every keyframe of this call is in place.
+      clearFacingHandles(list.keyframe_list, entry.time_offset);
+      holds.push({ list, entry, property });
+    } else if (kfEasing !== "linear") {
       if (!applyEasing(list.keyframe_list, entry, kfEasing)) {
         warnings.push(
           `easing '${kfEasing}' for ${kf.property} at ${kf.timeUs}us has no adjacent keyframe to ease against; ` +
@@ -289,12 +387,15 @@ export function addKeyframes(
     list.keyframe_list.sort((a, b) => a.time_offset - b.time_offset);
   }
 
+  const fps = typeof draft.fps === "number" && Number.isFinite(draft.fps) && draft.fps > 0 ? draft.fps : 30;
+  const holdKeyframes = holds.length > 0 ? applyHolds(holds, fps, warnings) : 0;
+
   const summary = commonKeyframes.map((l) => {
     const prop = Object.entries(PROPERTY_MAP).find(([, v]) => v === l.property_type)?.[0] ?? l.property_type;
     return { property: prop, count: l.keyframe_list.length };
   });
 
-  return { segmentId: seg.id, added: keyframes.length, lists: summary, warnings };
+  return { segmentId: seg.id, added: keyframes.length, lists: summary, warnings, holdKeyframes };
 }
 
 // --- Phase 1: transition / mask / bg-blur / text-style / text-anim ---

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -115,6 +115,70 @@ export interface InitOptions {
   templateDir: string; // path to template directory
   draftsDir: string; // path to CapCut drafts directory
   now?: number; // epoch ms — injectable clock for tests; defaults to Date.now()
+  /** Canvas override (see resolveCanvas); the template's canvas_config is kept when absent. */
+  canvas?: CanvasConfig;
+}
+
+export interface CanvasConfig {
+  width: number;
+  height: number;
+  ratio: string;
+}
+
+/**
+ * The aspect presets CapCut's canvas picker offers, at the pixel sizes the app
+ * itself uses for them. The bundled template is 1920x1080 "16:9", so a portrait
+ * short — the format most of this repo's users cut for — needed either a
+ * hand-written spec through `compile` or a second step; the most-diverged
+ * community fork shipped `init --width/--height` for exactly that.
+ */
+export const CANVAS_RATIO_PRESETS: Readonly<Record<string, { width: number; height: number }>> = {
+  "16:9": { width: 1920, height: 1080 },
+  "9:16": { width: 1080, height: 1920 },
+  "1:1": { width: 1080, height: 1080 },
+  "4:3": { width: 1440, height: 1080 },
+  "3:4": { width: 1080, height: 1440 },
+};
+
+/**
+ * Resolve `--ratio` / `--width` / `--height` into a canvas_config, or null when
+ * none was given. A preset alone picks its native size; explicit width+height
+ * win over the preset's size but keep its label; width+height without a preset
+ * get the matching preset label when the pair reduces to one, else "original"
+ * (the label CapCut writes for a custom canvas). One of width/height alone is an
+ * error — the app has no notion of a half-specified canvas.
+ */
+export function resolveCanvas(opts: { width?: number; height?: number; ratio?: string }): CanvasConfig | null {
+  const { width, height, ratio } = opts;
+  if (width === undefined && height === undefined && ratio === undefined) return null;
+  if ((width === undefined) !== (height === undefined)) {
+    throw new Error("--width and --height must be given together (or use --ratio <16:9|9:16|1:1|4:3|3:4>).");
+  }
+  for (const [flag, v] of [
+    ["--width", width],
+    ["--height", height],
+  ] as const) {
+    if (v !== undefined && (!Number.isInteger(v) || v <= 0)) {
+      throw new Error(`${flag} must be a positive integer pixel count, got: ${v}`);
+    }
+  }
+  let preset: { width: number; height: number } | undefined;
+  if (ratio !== undefined) {
+    preset = CANVAS_RATIO_PRESETS[ratio];
+    if (!preset) {
+      throw new Error(`Unknown --ratio ${ratio}. Presets: ${Object.keys(CANVAS_RATIO_PRESETS).join(", ")}`);
+    }
+  }
+  if (width !== undefined && height !== undefined) {
+    const label =
+      ratio ??
+      Object.entries(CANVAS_RATIO_PRESETS).find(([, p]) => p.width * height === p.height * width)?.[0] ??
+      "original";
+    return { width, height, ratio: label };
+  }
+  // ratio given, no explicit size: preset is defined here.
+  const p = preset as { width: number; height: number };
+  return { width: p.width, height: p.height, ratio: ratio as string };
 }
 
 /**
@@ -170,7 +234,12 @@ export function templateVersionWarning(templateVersion: string | null, storeVers
   );
 }
 
-export function initDraft(opts: InitOptions): { draftPath: string; filePath: string; registered: boolean } {
+export function initDraft(opts: InitOptions): {
+  draftPath: string;
+  filePath: string;
+  registered: boolean;
+  canvas: CanvasConfig | null;
+} {
   const draftPath = resolve(opts.draftsDir, opts.name);
   if (existsSync(draftPath)) {
     throw new Error(`Draft already exists: ${draftPath}. Delete it first or use a different name.`);
@@ -182,6 +251,21 @@ export function initDraft(opts: InitOptions): { draftPath: string; filePath: str
 
   // Find the draft file
   const candidates = ["draft_info.json", "draft_content.json"];
+
+  // Canvas override lands in EVERY timeline file the template ships (the
+  // bundled template carries draft_info.json and draft_content.json as
+  // mirrors): a canvas that differs between the two would be exactly the kind
+  // of drift sync-timelines exists to repair.
+  if (opts.canvas) {
+    for (const c of candidates) {
+      const fp = resolve(draftPath, c);
+      if (!existsSync(fp)) continue;
+      const parsed = JSON.parse(stripBom(readFileSync(fp, "utf-8"))) as Record<string, unknown>;
+      parsed.canvas_config = { ...opts.canvas };
+      writeFileSync(fp, JSON.stringify(parsed, null, 0), "utf-8");
+    }
+  }
+
   for (const c of candidates) {
     const fp = resolve(draftPath, c);
     if (existsSync(fp)) {
@@ -216,7 +300,7 @@ export function initDraft(opts: InitOptions): { draftPath: string; filePath: str
       } catch {
         registered = false;
       }
-      return { draftPath, filePath: fp, registered };
+      return { draftPath, filePath: fp, registered, canvas: opts.canvas ? { ...opts.canvas } : null };
     }
   }
   throw new Error(`No draft_info.json or draft_content.json found in template: ${opts.templateDir}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export const COMMANDS = [
   "migrate",
   "add-sfx",
   "chroma",
+  "matting",
   "prune",
   "register",
   "rename",
@@ -158,6 +159,7 @@ export const COMMANDS = [
   "render",
   "detect-scenes",
   "detect-silence",
+  "detect-retakes",
 ] as const;
 
 const HELP = `capcut-cli -- fast edits to CapCut projects
@@ -216,16 +218,21 @@ Detail (drill into one item):
   material   <project> <id>                     Full detail for one material
 
 Create:
-  init       <name> [--template <dir>] [--drafts <dir>]
+  init       <name> [--template <dir>] [--drafts <dir>] [--ratio <r> | --width <px> --height <px>]
              Create a new empty draft from template. Defaults:
                --template   bundled minimal template (no external repo needed)
                --drafts     this OS's CapCut draft store (CAPCUT_DRAFT_DIR overrides;
                             run capcut doctor to see the detected paths)
-  quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>]
+               --ratio      canvas preset: 16:9 (template default, 1920x1080),
+                            9:16 (1080x1920 portrait shorts), 1:1, 4:3, 3:4.
+                            --width/--height set an exact canvas (label from the
+                            matching preset, else "original"); both or neither.
+  quickstart <name> [--video <f>] [--audio <f>] [--srt <f>] [--drafts <dir>] [--ratio <r>]
              One-command first draft: create + add one input + lint + print the
              exact "open in CapCut" step. The fastest path from a file to an
              editable project. Pass at least one of --video / --audio / --srt.
              Durations come from ffprobe when available (5s placeholder if not).
+             --ratio / --width / --height set the canvas exactly as in init.
              Exit codes: 0 created & lint-clean · 2 created but lint errors
   compile    <spec.json> [--out <draftdir>] [--drafts <dir>] [--data <rows.jsonl|->]
              Build a whole draft from a declarative JSON spec (the inverse of
@@ -250,6 +257,13 @@ Preview:
                --scale <f>        Proxy scale of canvas dims (default 0.5)
                --fps <n>          Output fps (default draft fps)
                --burn-captions    Draw text-track segments onto the video
+               --soft-captions    Mux the text-track cues as a toggleable
+                                  subtitle stream (mov_text) instead of, or
+                                  as well as, burning them: the SRT is written
+                                  next to the output (<preview>.srt — players
+                                  auto-load it) and muxed as stream 0:s:0.
+                                  Skipped with a note when the ffmpeg build
+                                  has no mov_text encoder.
                --ffmpeg-cmd <p>   ffmpeg binary (default ffmpeg)
                --encoder <name>   Video encoder for -c:v (default libx264)
                --dry-run          Print the ffmpeg plan; do not execute
@@ -301,6 +315,20 @@ Analyze:
                --ffprobe-cmd <p>  ffprobe binary for the container duration
                                   (default ffprobe)
                --json             Force JSON output (the default; overrides -H)
+  detect-retakes <project> [--track-name <s>] [--window <s>] [--similarity <0..1>] [--min-words <n>]
+  detect-retakes --srt <file> [same options]
+             Find repeated takes — the sentence the speaker fluffed and said
+             again — from the draft's caption cues (every text track, or one
+             --track-name) or an SRT file, without touching the draft. A pair
+             is an earlier cue and a later cue whose normalised words are at
+             least --similarity alike (2·LCS/(a+b), default 0.8), both at least
+             --min-words long (default 4), the later one starting within
+             --window seconds of the earlier one ending (default 60 — the
+             guard against matching unrelated sentences half an hour apart).
+             The LATER take is the keeper: each earlier cue's span is a cut,
+             and the report lists cuts + the complementary keep spans in
+             seconds AND microseconds, the detect-silence shape, ready for
+             "capcut cut" / "capcut compile". --json forces JSON over -H.
 
 Add:
   add-audio  <project> <file-or-wikimedia-url> <start> <duration> [options]
@@ -389,7 +417,7 @@ Edit:
              remaining segment end across all tracks. Undo with restore.
   export-srt <project> [options]                Export subtitles to SRT/WebVTT
   export-ass <project> [--karaoke] [--out <f.ass>]  Export styled subtitles as ASS
-  export-timeline <project> [--out <f.otio>]    Export the cut as OpenTimelineIO for an NLE
+  export-timeline <project> [--out <f.otio>] [--captions markers]  Export the cut as OpenTimelineIO for an NLE
   import-timeline <f.otio> (--out <dir> | --into <project>)  Import an OpenTimelineIO cut
   batch      <project>                          Run multiple edits from stdin (JSONL)
   restore    <project> [--step N | --list]      Undo writes (latest .bak, or N writes back; --list history)
@@ -410,7 +438,7 @@ Maintenance & inspection:
              draft cannot disambiguate them; duplicate ids are refused,
              naming the entry that already owns them.
   prune      <project>                          Remove materials no segment references
-  register   <project-dir> [--apply] [--drafts <dir>]  Repair an EXISTING draft's
+  register   <project-dir> [--apply] [--materials] [--drafts <dir>]  Repair an EXISTING draft's
              registration metadata so the CapCut app lists it again (init only
              registers drafts it creates): recreates a missing/corrupt
              draft_meta_info.json sidecar and inserts/updates the draft's entry
@@ -424,6 +452,14 @@ Maintenance & inspection:
              and nothing is written. Refuses to write while the editor is
              running unless --force-write. Exits 2 on --apply when a target
              stays blocked (unknown store root, unreadable root_meta_info.json).
+             --materials additionally registers the timeline's local media in
+             the sidecar's draft_materials (the list CapCut 9.1 reads to decide
+             what is imported — empty, it shows every clip as "file
+             inaccessible" and asks to relink, pyCapCut#13). One entry per
+             distinct file, appended to the type-0 group; existing entries are
+             preserved, re-runs are no-ops, and the write folds into the same
+             sidecar write (one .bak). Entry shape per pyCapCut PR #14 — see
+             docs/draft-schema/00-overview.md for what is measured vs inferred.
   rename     <project> <new-name> [--drafts <dir>]  Rename a draft after
              creation: the draft folder on disk, plus draft_name and every
              self-referential path field in draft_meta_info.json and in the
@@ -474,10 +510,18 @@ Animate:
              plus optional "easing" overriding --easing per line.
              Properties: position_x, position_y, rotation, scale_x, scale_y,
                          uniform_scale, alpha, saturation, contrast, brightness, volume
+             Aliases:    scale=uniform_scale, x=position_x, y=position_y,
+                         opacity=alpha (the IR names agent pipelines use; stored
+                         under the canonical name, also accepted by compile)
              Values: "1.5", "50%" (alpha/volume), "45deg" (rotation),
                      "+0.5"/"-0.3" (saturation/contrast/brightness)
              Easing: linear (default), ease-in, ease-out, ease-in-out — written
                      as CapCut bezier handles (ease-out = the UI's "Cubic Out").
+                     hold = a step: CapCut always interpolates, so the value is
+                     held by a helper keyframe one frame before the NEXT
+                     keyframe on that property (the ramp happens inside one
+                     frame). Needs a later keyframe; warns otherwise. Reported
+                     as hold_keyframes.
                      Easing needs an adjacent keyframe on the same property: a
                      lone eased keyframe stays linear (warns) and picks up the
                      curve when its pair is added with an easing. A linear
@@ -644,6 +688,16 @@ Caption (v0.4 — real subtitle objects, fixes import-srt mimicry):
                --color-cycle <#hex1,#hex2,...>
                                     Rotate the BASE text colour per cue in
                                     list order (independent of emphasis)
+               --script <file>      The known transcript: whisper's word timing
+                                    is kept, the script's wording (names, terms,
+                                    punctuation) replaces what it heard. Each
+                                    non-empty script line is one cue (split at
+                                    --max-chars, default 42); with --karaoke the
+                                    timed script words group as usual. The
+                                    result's "script" block reports matched /
+                                    substituted / inserted words; below 50%
+                                    matched it warns that the script probably
+                                    belongs to other audio.
              Precedence: --color-cycle wins over the style-ref/preset base
              colour per cue; keyword emphasis sits on top of base/karaoke
              styling and overrides the matched words' colour/size; with
@@ -673,6 +727,12 @@ Sound effects + chroma (v0.5):
   chroma     <project> <id> --off
              Apply chroma key (green-screen) to a video segment.
              --intensity: how aggressively to key out the color (0-1, default 0.5).
+  matting    <project> <id> [--off]
+             Smart matting ("Remove background" / 智能抠像) on a video or photo
+             segment: writes flag 3 (smart portrait matting) on the segment's
+             VIDEO MATERIAL — the app computes the cutout itself on next open.
+             --off writes the documented flag-0 object. Per material: segments
+             sharing the material (reported as shared_segments) change too.
 
 Render queue (v0.4 — experimental):
   export     <drafts-dir> --batch [options]
@@ -755,17 +815,25 @@ Subtitles (Phase 3):
                               highlight colour becomes PrimaryColour, the
                               base colour SecondaryColour.
                --out <f.ass>  Write to a file and print a JSON summary.
-  export-timeline <project> [--out <file.otio>]
+  export-timeline <project> [--out <file.otio>] [--captions markers]
              Export video/audio tracks as OpenTimelineIO JSON (stdout, or
              --out): clip order, trims, gaps, and speed (LinearTimeWarp) —
              the exit ramp when an app build rejects the draft. DaVinci
              Resolve imports .otio natively. Text tracks are skipped with a
-             pointer to export-srt.
+             pointer to export-srt — OTIO has no title schema — unless
+             --captions markers: then every caption cue travels as a timeline
+             marker on the Stack (name = cue text, marked_range = cue timing,
+             metadata.capcut.kind = "caption"), which Resolve/Premiere import
+             as timeline markers and import-timeline turns back into the text
+             track. Default "skip" keeps today's output byte-identical.
   import-timeline <file.otio> (--out <new-project> | --into <project>)
              The inverse of export-timeline: read OpenTimelineIO JSON (the
              schema set export-timeline emits) and build the cut as a draft.
              Clips become video/audio segments with their source ranges, gaps
              become timeline offsets, LinearTimeWarp becomes segment speed.
+             Timeline markers that export-timeline --captions markers wrote
+             (metadata.capcut.kind = "caption") become text segments again on
+             the recorded track name; other timeline markers are reported.
              Media that exists on disk is staged into assets/ (the add-video
              copy); missing media becomes a placeholder material to swap with
              replace-media. Unsupported OTIO features are reported in the
@@ -808,6 +876,18 @@ interface Flags {
   drafts?: string;
   // sync-timelines
   nested?: boolean;
+  // register
+  materials?: boolean;
+  // export-timeline
+  captions?: string;
+  // caption --script
+  script?: string;
+  // detect-retakes
+  window?: number;
+  similarity?: number;
+  minWords?: number;
+  // render
+  softCaptions?: boolean;
   // lint
   pip?: boolean;
   // catalogue
@@ -1106,6 +1186,20 @@ function parseFlags(args: string[]): { positional: string[]; flags: Flags } {
       flags.duration = args[++i];
     } else if (a === "--off") {
       flags.off = true;
+    } else if (a === "--materials") {
+      flags.materials = true;
+    } else if (a === "--captions" && i + 1 < args.length) {
+      flags.captions = args[++i];
+    } else if (a === "--script" && i + 1 < args.length) {
+      flags.script = args[++i];
+    } else if (a === "--window" && i + 1 < args.length) {
+      flags.window = parseFloat(args[++i]);
+    } else if (a === "--similarity" && i + 1 < args.length) {
+      flags.similarity = parseFloat(args[++i]);
+    } else if (a === "--min-words" && i + 1 < args.length) {
+      flags.minWords = parseInt(args[++i], 10);
+    } else if (a === "--soft-captions") {
+      flags.softCaptions = true;
     } else if (a === "--center-x" && i + 1 < args.length) {
       flags.centerX = parseFloat(args[++i]);
     } else if (a === "--center-y" && i + 1 < args.length) {
@@ -1967,12 +2061,25 @@ async function cmdHarvestEnumsAdd(positional: string[], flags: Flags): Promise<v
 // silent (text tracks point at export-srt).
 async function cmdExportTimeline(draft: Draft, flags: Flags): Promise<void> {
   const { draftToOtio } = await import("./interchange.js");
-  const { doc, stats } = draftToOtio(draft);
+  const captions = flags.captions ?? "skip";
+  if (captions !== "skip" && captions !== "markers") {
+    die(`--captions must be skip|markers (got ${captions}). markers = caption cues as OTIO timeline markers.`);
+  }
+  const { doc, stats } = draftToOtio(draft, { captions });
   const serialized = `${JSON.stringify(doc, null, 2)}\n`;
   if (flags.out) {
     writeFileSync(flags.out, serialized, "utf-8");
     out(
-      { ok: true, out: flags.out, tracks: stats.tracks, clips: stats.clips, gaps: stats.gaps, skipped: stats.skipped },
+      {
+        ok: true,
+        out: flags.out,
+        tracks: stats.tracks,
+        clips: stats.clips,
+        gaps: stats.gaps,
+        // Present only when asked for, so the default JSON stays byte-identical.
+        ...(captions === "markers" ? { captions: stats.captions } : {}),
+        skipped: stats.skipped,
+      },
       flags,
     );
   } else {
@@ -1990,6 +2097,8 @@ const IMPORT_TIMELINE_USAGE = "capcut import-timeline <file.otio> (--out <new-pr
 interface ImportApplyResult {
   tracks: number;
   clips: number;
+  /** Caption cues rebuilt as text segments from the document's caption markers. */
+  captions: number;
   placeholders: Array<{ track: string; clip: string; path: string | null }>;
 }
 
@@ -1998,15 +2107,18 @@ interface ImportApplyResult {
 // into an existing track by name could overlap the segments already there, so
 // a name collision de-collides with a numeric suffix instead.
 async function applyImportPlan(draft: Draft, filePath: string, plan: ImportPlan): Promise<ImportApplyResult> {
-  const { addAudio, addVideo } = await import("./factory.js");
-  const result: ImportApplyResult = { tracks: 0, clips: 0, placeholders: [] };
+  const { addAudio, addText, addVideo } = await import("./factory.js");
+  const result: ImportApplyResult = { tracks: 0, clips: 0, captions: 0, placeholders: [] };
   const claimed = new Set(draft.tracks.map((t) => `${t.type} ${t.name}`));
+  const claimTrack = (kind: string, base: string): string => {
+    let name = base;
+    for (let n = 2; claimed.has(`${kind} ${name}`); n++) name = `${base} (${n})`;
+    claimed.add(`${kind} ${name}`);
+    return name;
+  };
   for (const track of plan.tracks) {
     if (track.clips.length === 0) continue;
-    const base = track.name || track.kind;
-    let name = base;
-    for (let n = 2; claimed.has(`${track.kind} ${name}`); n++) name = `${base} (${n})`;
-    claimed.add(`${track.kind} ${name}`);
+    const name = claimTrack(track.kind, track.name || track.kind);
 
     for (const clip of track.clips) {
       // Media on disk is staged into assets/ (the add-video/add-audio copy);
@@ -2038,6 +2150,23 @@ async function applyImportPlan(draft: Draft, filePath: string, plan: ImportPlan)
       }
       if (placeholder) result.placeholders.push({ track: name, clip: clip.name, path: clip.mediaPath });
       result.clips++;
+    }
+    result.tracks++;
+  }
+
+  // Caption markers → text segments, grouped back onto the track names the
+  // export recorded (one fresh text track per name, same de-collision rule).
+  const byTrack = new Map<string, typeof plan.captions>();
+  for (const cue of plan.captions) {
+    const list = byTrack.get(cue.track) ?? [];
+    list.push(cue);
+    byTrack.set(cue.track, list);
+  }
+  for (const [base, cues] of byTrack) {
+    const name = claimTrack("text", base);
+    for (const cue of cues) {
+      addText(draft, filePath, { text: cue.text, start: cue.startUs, duration: cue.durationUs, trackName: name });
+      result.captions++;
     }
     result.tracks++;
   }
@@ -2101,6 +2230,9 @@ async function cmdImportTimeline(positional: string[], flags: Flags): Promise<vo
       tracks: applied.tracks,
       clips: applied.clips,
       gaps: plan.gaps,
+      // Present only when the document carried caption markers, so documents
+      // without them keep the previous JSON shape byte-for-byte.
+      ...(plan.captions.length > 0 ? { captions: applied.captions } : {}),
       placeholders: applied.placeholders,
       duration_us: draft.duration,
       skipped: plan.skipped,
@@ -2632,9 +2764,15 @@ async function cmdAddText(draft: Draft, filePath: string, positional: string[], 
 }
 
 async function cmdKeyframe(draft: Draft, filePath: string, positional: string[], flags: Flags): Promise<void> {
-  const { addKeyframes, keyframeProperties, parseKeyframeValue } = await import("./decorators.js");
+  const { addKeyframes, keyframeProperties, keyframePropertyAliases, parseKeyframeValue } = await import(
+    "./decorators.js"
+  );
   const segId = positional[2];
   if (!segId) die("Usage: capcut keyframe <project> <id> <property> <time> <value>  (or --batch with JSONL on stdin)");
+  const propertyHelp = (): string =>
+    `Properties: ${keyframeProperties().join(", ")}\nAliases: ${Object.entries(keyframePropertyAliases())
+      .map(([alias, canonical]) => `${alias}=${canonical}`)
+      .join(", ")}`;
 
   const inputs: KeyframeInput[] = [];
 
@@ -2662,9 +2800,7 @@ async function cmdKeyframe(draft: Draft, filePath: string, positional: string[],
     const timeStr = positional[4];
     const valueStr = positional[5];
     if (!property || !timeStr || valueStr === undefined) {
-      die(
-        `Usage: capcut keyframe <project> <id> <property> <time> <value>\nProperties: ${keyframeProperties().join(", ")}`,
-      );
+      die(`Usage: capcut keyframe <project> <id> <property> <time> <value>\n${propertyHelp()}`);
     }
     const timeUs = parseTimeInput(timeStr);
     const value = parseKeyframeValue(property, valueStr);
@@ -2680,6 +2816,8 @@ async function cmdKeyframe(draft: Draft, filePath: string, positional: string[],
       id: result.segmentId,
       added: result.added,
       lists: result.lists,
+      // Only when a hold was emulated, so existing output stays byte-identical.
+      ...(result.holdKeyframes > 0 ? { hold_keyframes: result.holdKeyframes } : {}),
       ...(result.warnings.length ? { warnings: result.warnings } : {}),
     },
     flags,
@@ -3601,9 +3739,15 @@ async function cmdCaption(draft: Draft, filePath: string, flags: Flags): Promise
     die("Missing --audio <path> or --from-segment <id>. One is required.");
   }
   const emphasis = await keywordEmphasisFromFlags(flags);
+  let scriptText: string | undefined;
+  if (flags.script !== undefined) {
+    if (!existsSync(flags.script)) die(`--script file not found: ${flags.script}`);
+    scriptText = stripBom(readFileSync(flags.script, "utf-8"));
+  }
   const result = captionDraft(draft, {
     audio: flags.audio,
     fromSegment: flags.fromSegment,
+    scriptText,
     whisperCmd: flags.whisperCmd,
     whisperEngine: flags.whisperEngine,
     whisperModel: flags.whisperModel,
@@ -3621,6 +3765,15 @@ async function cmdCaption(draft: Draft, filePath: string, flags: Flags): Promise
     colorCycle: emphasis.cycle,
   });
   saveDraft(filePath, draft);
+  // A script that barely matches the recognised words is almost certainly the
+  // wrong script for this audio: the timing would be nonsense. Warn, never
+  // refuse — a heavy accent or a noisy room legitimately lowers the ratio.
+  if (result.script && result.script.match_ratio < 0.5 && !flags.quiet) {
+    process.stderr.write(
+      `Warning: only ${Math.round(result.script.match_ratio * 100)}% of the script's words matched what whisper heard ` +
+        `(${result.script.matched}/${result.script.script_words}). Check that --script belongs to this audio.\n`,
+    );
+  }
   out(result, flags);
 }
 
@@ -3684,6 +3837,20 @@ async function cmdChroma(draft: Draft, filePath: string, positional: string[], f
     intensity: flags.intensity,
   });
   saveDraft(filePath, draft);
+  out(result, flags);
+}
+
+async function cmdMatting(draft: Draft, filePath: string, positional: string[], flags: Flags): Promise<void> {
+  const { clearMatting, setMatting } = await import("./matting.js");
+  const segId = positional[2];
+  if (!segId) die("Usage: capcut matting <project> <id> [--off]");
+  const result = flags.off ? clearMatting(draft, segId) : setMatting(draft, segId);
+  saveDraft(filePath, draft);
+  if (result.shared_segments.length > 0 && !flags.quiet) {
+    process.stderr.write(
+      `Note: material ${result.materialId} is shared by ${result.shared_segments.length} other segment(s); matting is per material, so they change too.\n`,
+    );
+  }
   out(result, flags);
 }
 
@@ -3918,8 +4085,13 @@ async function cmdDiagnose(projectPath: string | undefined, flags: Flags): Promi
 // root_meta_info.json).
 async function cmdRegister(projectPath: string | undefined, flags: Flags): Promise<number> {
   const { applyDraftRegistration, planDraftRegistration } = await import("./factory.js");
-  if (!projectPath) die("Usage: capcut register <project-dir> [--apply] [--drafts <dir>]");
-  const result = planDraftRegistration(projectPath, { draftsDir: flags.drafts });
+  if (!projectPath) die("Usage: capcut register <project-dir> [--apply] [--materials] [--drafts <dir>]");
+  const planWithMaterials = async (): Promise<Awaited<ReturnType<typeof planDraftRegistration>>> => {
+    const planned = planDraftRegistration(projectPath, { draftsDir: flags.drafts });
+    if (flags.materials) await addMaterialsToRegistrationPlan(planned);
+    return planned;
+  };
+  const result = await planWithMaterials();
   const { plan } = result;
 
   const warnBlocked = (): void => {
@@ -3929,12 +4101,24 @@ async function cmdRegister(projectPath: string | undefined, flags: Flags): Promi
     }
   };
 
+  const materials = (plan as RegistrationPlanWithMaterials).materials;
+  const describeMaterials = (): void => {
+    if (flags.quiet || !materials) return;
+    if (materials.action === "update") {
+      process.stderr.write(`plan: update draft_meta_info.json draft_materials (${materials.detail})\n`);
+    } else if (materials.action === "blocked") {
+      process.stderr.write(`WARNING draft_materials: ${materials.detail}\n`);
+    }
+  };
+
   if (!flags.apply) {
     const message = plan.needs_repair
       ? `Would write ${plan.repairs.join(", ")}. Re-run with --apply to write.`
       : plan.blocked.length > 0
         ? `Registration cannot be verified or repaired: ${plan.blocked.join(", ")} — see targets.`
-        : `Draft is registered: draft_meta_info.json and the store's root_meta_info.json entry agree with ${plan.identity_source}.`;
+        : materials
+          ? `Draft is registered and its ${materials.referenced} referenced media file(s) are in draft_materials.`
+          : `Draft is registered: draft_meta_info.json and the store's root_meta_info.json entry agree with ${plan.identity_source}.`;
     out({ ok: plan.blocked.length === 0, applied: false, message, ...plan }, flags);
     if (!flags.quiet) {
       for (const target of plan.targets) {
@@ -3942,6 +4126,7 @@ async function cmdRegister(projectPath: string | undefined, flags: Flags): Promi
           process.stderr.write(`plan: ${target.action} ${target.file} (${target.detail})\n`);
         }
       }
+      describeMaterials();
       warnBlocked();
       process.stderr.write(plan.needs_repair ? "Plan only — re-run with --apply to write.\n" : `${message}\n`);
     }
@@ -3979,7 +4164,7 @@ async function cmdRegister(projectPath: string | undefined, flags: Flags): Promi
 
   const { applied, backups } = applyDraftRegistration(result, { forceWrite: flags.forceWrite === true });
 
-  const verify = planDraftRegistration(projectPath, { draftsDir: flags.drafts });
+  const verify = await planWithMaterials();
   if (verify.plan.needs_repair) {
     die(
       `register wrote ${applied.join(", ")} but the draft still needs repair (${verify.plan.repairs.join(", ")}). ` +
@@ -3988,10 +4173,64 @@ async function cmdRegister(projectPath: string | undefined, flags: Flags): Promi
   }
   const ok = plan.blocked.length === 0;
   out({ ok, applied, backups, ...verify.plan }, flags);
-  if (!flags.quiet) process.stderr.write(`Registered from ${plan.identity_source}: wrote ${applied.join(", ")}\n`);
+  if (!flags.quiet) {
+    process.stderr.write(`Registered from ${plan.identity_source}: wrote ${applied.join(", ")}\n`);
+    if (materials?.action === "update") {
+      process.stderr.write(
+        `Registered ${materials.to_register.length} media file(s) in draft_materials — reopen the draft in CapCut to clear the relink prompt.\n`,
+      );
+    }
+  }
   warnBlocked();
   return ok ? 0 : 2;
 }
+
+// `register --materials`: fold the draft_materials registration (pyCapCut#13,
+// the CapCut 9.1 "file inaccessible" prompt) into register's plan. The
+// registration lives in the same sidecar register already repairs, so when the
+// plan is about to create/rewrite draft_meta_info.json the media entries are
+// merged into THAT write (one file, one .bak, one concurrency check); otherwise
+// the on-disk sidecar is the base. The timeline is read from the plan's
+// identity file — never through loadDraft, for the same reason register itself
+// avoids it (the sidecar files discovery looks at may be exactly what is missing).
+async function addMaterialsToRegistrationPlan(
+  result: Awaited<ReturnType<typeof import("./factory.js").planDraftRegistration>>,
+): Promise<void> {
+  const { planDraftMaterials } = await import("./materials-register.js");
+  const { plan } = result;
+  const sidecarPath = path.resolve(plan.project_dir, "draft_meta_info.json");
+  const draft = JSON.parse(stripBom(readFileSync(plan.content_path, "utf-8"))) as Draft;
+  const sidecarWrite = result.writes.find((w) => w.file === "draft_meta_info.json");
+  const onDiskRaw = existsSync(sidecarPath) ? stripBom(readFileSync(sidecarPath, "utf-8")) : null;
+  const baseRaw = sidecarWrite ? sidecarWrite.content : onDiskRaw;
+  let base: Record<string, unknown> | null = null;
+  if (baseRaw !== null) {
+    try {
+      const parsed = JSON.parse(baseRaw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) base = parsed as Record<string, unknown>;
+    } catch {
+      base = null;
+    }
+  }
+  const { target, fixed } = planDraftMaterials(draft, base, { sidecarPath, projectDir: plan.project_dir });
+  if (fixed) {
+    const content = JSON.stringify(fixed, null, 0);
+    if (sidecarWrite) sidecarWrite.content = content;
+    else result.writes.push({ file: "draft_meta_info.json", path: sidecarPath, content, previous: onDiskRaw });
+    if (!plan.repairs.includes("draft_meta_info.json")) plan.repairs.push("draft_meta_info.json");
+    plan.needs_repair = true;
+  }
+  if (target.action === "blocked" && !plan.blocked.includes("draft_meta_info.json")) {
+    plan.blocked.push("draft_meta_info.json");
+  }
+  (plan as RegistrationPlanWithMaterials).materials = target;
+}
+
+type RegistrationPlanWithMaterials = Awaited<
+  ReturnType<typeof import("./factory.js").planDraftRegistration>
+>["plan"] & {
+  materials?: import("./materials-register.js").MaterialsRegistrationTarget;
+};
 
 // `rename` gives a draft a new display name + folder name after creation —
 // no tool in the ecosystem has this (VectCutAPI#45): users recreate whole
@@ -4643,6 +4882,8 @@ const SUMMARIES: Record<string, string> = {
   migrate: "Apply known schema migrations across version boundaries.",
   "add-sfx": "Add a sound effect on a dedicated track.",
   chroma: "Green-screen / chroma key a video segment, or --off.",
+  matting:
+    "Smart matting (background removal) on a video/photo segment's material — flag 3 on; --off writes the documented flag-0 object.",
   enums: "List enum slugs (transitions, masks, effects, ...) by category.",
   catalogue: "Find a resource id by name across every category, harvested entries included.",
   doctor: "Environment preflight (Node, whisper, API key, project dir).",
@@ -4651,7 +4892,7 @@ const SUMMARIES: Record<string, string> = {
     "Reconcile drifted timeline mirrors (template-2.tmp, draft_info.json) from a read-only draft_content.json (plan with mtimes by default; --apply rewrites only the drifted mirrors).",
   prune: "Remove materials no segment references.",
   register:
-    "Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak).",
+    "Repair an existing draft's registration metadata (draft_meta_info.json + root_meta_info.json entry) from a read-only draft_content.json so the CapCut app lists it (plan by default; --apply writes with .bak); --materials also registers the timeline's media in draft_materials (the CapCut 9.1 relink-prompt fix).",
   rename:
     "Rename a draft after creation: the folder on disk plus draft_name and every self-referential path in draft_meta_info.json and the store's root_meta_info.json entry, transactionally (refuses when the target folder exists).",
   relink: "Repair broken media paths (--dir or --from/--to).",
@@ -4673,6 +4914,8 @@ const SUMMARIES: Record<string, string> = {
     "Detect scene-change cut points in a video (ffmpeg scene filter); prints cuts + segments to seed compile/cut.",
   "detect-silence":
     "Detect silence spans in a media file (ffmpeg silencedetect); prints silences + keep segments to seed compile/cut.",
+  "detect-retakes":
+    "Find repeated takes in the draft's captions (or an SRT): windowed word-sequence similarity, later take kept; prints cuts + keep segments to seed compile/cut.",
 };
 
 // `describe` emits a machine-readable tool spec for LLM/agent callers, so they
@@ -5062,6 +5305,7 @@ async function cmdRender(draft: Draft, filePath: string, flags: Flags): Promise<
     ffmpegCmd: flags.ffmpegCmd,
     encoder: flags.encoder,
     burnCaptions: flags.burnCaptions,
+    softCaptions: flags.softCaptions,
     allVideoTracks: flags.allVideoTracks,
     dryRun: isDryRun(),
     progress: flags.progress,
@@ -5183,6 +5427,99 @@ async function cmdDetectSilence(positional: string[], flags: Flags): Promise<voi
     }
     console.log(
       "Next: pipe the keep segments into `capcut compile` (one clip per segment) or `capcut cut` to drop the silences.",
+    );
+    return;
+  }
+  out(report, flags);
+}
+
+const DETECT_RETAKES_USAGE =
+  "capcut detect-retakes <project> [--track-name <s>] [--window <s>] [--similarity <0..1>] [--min-words <n>]  |  detect-retakes --srt <file>";
+
+// Retake detection reads caption cues — from the draft's text tracks (the
+// project form, dispatched through loadDraft like every read command) or from
+// an SRT file (no project) — and never writes. The three guards are explicit
+// flags; see src/retakes.ts for why each exists.
+async function cmdDetectRetakes(draft: Draft | null, flags: Flags): Promise<void> {
+  const { buildRetakeReport } = await import("./retakes.js");
+  const { timecode } = await import("./scenes.js");
+  const window = flags.window ?? 60;
+  if (!Number.isFinite(window) || window <= 0) die("--window must be > 0 seconds");
+  const similarity = flags.similarity ?? 0.8;
+  if (!Number.isFinite(similarity) || similarity <= 0 || similarity > 1) die("--similarity must be in (0, 1]");
+  const minWords = flags.minWords ?? 4;
+  if (!Number.isInteger(minWords) || minWords < 1) die("--min-words must be a positive integer");
+
+  let cues: Array<{ text: string; startUs: number; endUs: number }>;
+  let source: string;
+  let durationUs: number | null = null;
+  if (draft === null) {
+    const { parseSrt } = await import("./srt.js");
+    const srtPath = flags.srt as string;
+    if (!existsSync(srtPath)) die(`--srt file not found: ${srtPath}`);
+    cues = parseSrt(stripBom(readFileSync(srtPath, "utf-8"))).map((c) => ({
+      text: c.text,
+      startUs: c.startUs,
+      endUs: c.endUs,
+    }));
+    source = srtPath;
+  } else {
+    const tracks = getTracksByType(draft, "text").filter(
+      (t) => flags.trackName === undefined || t.name === flags.trackName,
+    );
+    if (tracks.length === 0) {
+      die(
+        flags.trackName === undefined
+          ? "The draft has no text track to read cues from — run `capcut caption` first, or pass --srt <file>."
+          : `No text track named "${flags.trackName}" — see \`capcut tracks\`.`,
+      );
+    }
+    cues = tracks.flatMap((track) =>
+      track.segments.flatMap((seg) => {
+        const mat = findMaterial(draft.materials.texts, seg.material_id);
+        if (!mat) return [];
+        const text = extractText(mat.content);
+        if (!text) return [];
+        return [
+          {
+            text,
+            startUs: seg.target_timerange.start,
+            endUs: seg.target_timerange.start + seg.target_timerange.duration,
+          },
+        ];
+      }),
+    );
+    source = tracks.map((t) => t.name).join(", ");
+    durationUs = typeof draft.duration === "number" && draft.duration > 0 ? draft.duration : null;
+  }
+  const report = buildRetakeReport(cues, durationUs, { window, similarity, minWords }, source);
+  if (flags.human && !flags.json) {
+    console.log(`Source:     ${report.source}`);
+    console.log(`Cues:       ${report.cues}`);
+    console.log(
+      `Guards:     window ${report.window}s · similarity ≥ ${report.similarity} · min words ${report.min_words}`,
+    );
+    console.log(`Retakes:    ${report.retakes.length}`);
+    for (const [i, pair] of report.retakes.entries()) {
+      console.log(
+        `  ${String(i + 1).padStart(3)}  ${timecode(pair.earlier.start)} - ${timecode(pair.earlier.end)}  →  ` +
+          `${timecode(pair.later.start)} - ${timecode(pair.later.end)}  sim ${pair.similarity.toFixed(3)}`,
+      );
+      console.log(`       cut:  ${pair.earlier.text}`);
+      console.log(`       keep: ${pair.later.text}`);
+    }
+    console.log(`Cuts:       ${report.cuts.length}`);
+    for (const [i, s] of report.cuts.entries()) {
+      const end = s.end === null ? "end" : timecode(s.end);
+      console.log(`  ${String(i + 1).padStart(3)}  ${timecode(s.start)} - ${end}`);
+    }
+    console.log(`Keeps:      ${report.keeps.length}`);
+    for (const [i, s] of report.keeps.entries()) {
+      const end = s.end === null ? "end" : timecode(s.end);
+      console.log(`  ${String(i + 1).padStart(3)}  ${timecode(s.start)} - ${end}`);
+    }
+    console.log(
+      "Next: pipe the keep segments into `capcut compile` (one clip per segment) or `capcut cut` to drop the earlier takes.",
     );
     return;
   }
@@ -5395,14 +5732,25 @@ async function main(): Promise<void> {
     if (!name) die("Missing name. Usage: capcut init <name> [--template <dir>] [--drafts <dir>]");
     const templateDir = resolveTemplateDir(flags);
     const draftsDir = flags.drafts ?? requireDraftsDir();
-    const { initDraft } = await import("./factory.js");
-    const result = initDraft({ name, templateDir, draftsDir });
+    const { initDraft, resolveCanvas } = await import("./factory.js");
+    const canvas = resolveCanvas({ width: flags.width, height: flags.height, ratio: flags.ratio });
+    const result = initDraft({ name, templateDir, draftsDir, canvas: canvas ?? undefined });
     out(
-      { ok: true, name, draft_path: result.draftPath, file_path: result.filePath, registered: result.registered },
+      {
+        ok: true,
+        name,
+        draft_path: result.draftPath,
+        file_path: result.filePath,
+        registered: result.registered,
+        canvas: result.canvas,
+      },
       flags,
     );
     if (!flags.quiet) {
       process.stderr.write(`Created: ${result.draftPath}\n`);
+      if (result.canvas) {
+        process.stderr.write(`Canvas: ${result.canvas.width}x${result.canvas.height} (${result.canvas.ratio})\n`);
+      }
       if (result.registered) {
         process.stderr.write(`Registered in CapCut's project list — restart CapCut to see it.\n`);
       } else {
@@ -5421,6 +5769,8 @@ async function main(): Promise<void> {
     const templateDir = resolveTemplateDir(flags);
     const draftsDir = flags.drafts ?? requireDraftsDir();
     const { runQuickstart } = await import("./quickstart.js");
+    const { resolveCanvas } = await import("./factory.js");
+    const canvas = resolveCanvas({ width: flags.width, height: flags.height, ratio: flags.ratio });
     const result = runQuickstart({
       name,
       templateDir,
@@ -5429,6 +5779,7 @@ async function main(): Promise<void> {
       audio: flags.audio,
       srt: flags.srt,
       ffprobeCmd: flags.ffprobeCmd,
+      canvas: canvas ?? undefined,
     });
     out(result, flags);
     if (!flags.quiet) {
@@ -5466,6 +5817,14 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  // `detect-retakes --srt <file>` reads cues from a subtitle file — no draft
+  // needed; the project form falls through to the read-command switch below.
+  if (cmd === "detect-retakes" && flags.srt !== undefined) {
+    if (projectPath) die(`--srt reads cues from the file; drop the <project> argument. Usage: ${DETECT_RETAKES_USAGE}`);
+    await cmdDetectRetakes(null, flags);
+    process.exit(0);
+  }
+
   if (!projectPath) die("Missing project path. Run 'capcut --help' for usage.");
 
   const { draft, filePath } = loadDraft(projectPath);
@@ -5489,6 +5848,9 @@ async function main(): Promise<void> {
       break;
     case "render":
       await cmdRender(draft, filePath, flags);
+      break;
+    case "detect-retakes":
+      await cmdDetectRetakes(draft, flags);
       break;
     case "version":
       cmdVersion(draft, filePath, flags);
@@ -5696,6 +6058,10 @@ async function main(): Promise<void> {
     case "chroma":
       requireArgs(positional, 3, "capcut chroma <project> <id> --color <#RRGGBB>  |  --off");
       await cmdChroma(draft, filePath, positional, flags);
+      break;
+    case "matting":
+      requireArgs(positional, 3, "capcut matting <project> <id> [--off]");
+      await cmdMatting(draft, filePath, positional, flags);
       break;
     default:
       die(`Unknown command: ${cmd}. Run 'capcut --help' for usage.`);

--- a/src/interchange.ts
+++ b/src/interchange.ts
@@ -1,5 +1,6 @@
 import { basename } from "node:path";
 import type { Draft, Segment } from "./draft.js";
+import { extractText } from "./draft.js";
 import { framesFor } from "./time.js";
 
 /**
@@ -15,8 +16,14 @@ import { framesFor } from "./time.js";
  *
  * Deliberate scope:
  * - Video and audio tracks only. Text/caption tracks are skipped with a
- *   pointer to `export-srt` (OTIO has no standard title schema); sticker /
- *   effect / filter tracks have no portable equivalent and are skipped too.
+ *   pointer to `export-srt` (OTIO has no standard title schema — the request
+ *   has been open since 2017, OpenTimelineIO#62), UNLESS `captions: "markers"`
+ *   is asked for: then every caption cue becomes a timeline marker on the
+ *   Stack (name = cue text, marked_range = cue timing), which is what NLEs
+ *   already round-trip — Resolve and Premiere import Stack markers as timeline
+ *   markers — so the captions at least survive the handoff as positioned notes
+ *   and `import-timeline` can rebuild the text track from them. Sticker /
+ *   effect / filter tracks have no portable equivalent and are skipped.
  *   Every skip is reported, never silent.
  * - `speed` maps to a LinearTimeWarp effect (time_scalar = speed), matching
  *   OTIO semantics: timeline duration = source_range.duration / time_scalar,
@@ -44,7 +51,45 @@ export interface OtioStats {
   tracks: number;
   clips: number;
   gaps: number;
+  /** Caption cues written as timeline markers (`captions: "markers"`); 0 otherwise. */
+  captions: number;
   skipped: OtioSkip[];
+}
+
+export interface OtioExportOptions {
+  /** How text/caption tracks travel: dropped with a note (default) or as Stack markers. */
+  captions?: "skip" | "markers";
+}
+
+/** The marker colour every caption marker carries — one colour, so an NLE user can filter them. */
+export const CAPTION_MARKER_COLOR = "YELLOW";
+
+/**
+ * One caption cue as an OTIO Marker.1 (the 0.14-era schema, which every
+ * reader still accepts and newer libraries upgrade on read). The cue text is
+ * the marker name; it is repeated under metadata.capcut.text because some
+ * NLEs shorten or rewrite marker names on import, and `import-timeline` needs
+ * the exact text back. metadata.Resolve_OTIO.Note is DaVinci Resolve's own
+ * marker-note field (it writes and reads it on its .otio round trips); harmless
+ * elsewhere, it makes the cue text show in Resolve's marker panel too.
+ */
+function captionMarker(
+  text: string,
+  startFrames: number,
+  durationFrames: number,
+  rate: number,
+  capcut: Record<string, unknown>,
+): OtioObject {
+  return {
+    OTIO_SCHEMA: "Marker.1",
+    color: CAPTION_MARKER_COLOR,
+    marked_range: timeRange(startFrames, durationFrames, rate),
+    metadata: {
+      Resolve_OTIO: { Keywords: [], Note: text },
+      capcut: { kind: "caption", text, ...capcut },
+    },
+    name: text,
+  };
 }
 
 function rationalTime(value: number, rate: number): OtioObject {
@@ -170,13 +215,64 @@ export interface ImportTrackPlan {
   clips: ImportClipPlan[];
 }
 
+export interface ImportCaptionPlan {
+  text: string;
+  startUs: number;
+  durationUs: number;
+  /** Text track name recorded at export (falls back to "captions"). */
+  track: string;
+}
+
 export interface ImportPlan {
   name: string;
   rate: number;
   tracks: ImportTrackPlan[];
   clips: number;
   gaps: number;
+  /** Caption cues recovered from Stack markers that export-timeline --captions markers wrote. */
+  captions: ImportCaptionPlan[];
   skipped: OtioSkip[];
+}
+
+/**
+ * Timeline (Stack) markers: the ones export-timeline wrote for captions carry
+ * metadata.capcut.kind === "caption" and come back as caption cues; any other
+ * timeline marker (an editor's own notes) has no CapCut equivalent and is
+ * reported once, with the count, like every other skip.
+ */
+function captionsFromStackMarkers(markers: unknown, rate: number, skipped: OtioSkip[]): ImportCaptionPlan[] {
+  const captions: ImportCaptionPlan[] = [];
+  if (!Array.isArray(markers)) return captions;
+  let foreign = 0;
+  for (const marker of markers) {
+    const m = marker as OtioObject;
+    const capcut = (m.metadata as { capcut?: Record<string, unknown> } | undefined)?.capcut;
+    if (!capcut || capcut.kind !== "caption") {
+      foreign++;
+      continue;
+    }
+    const range = timeRangeUs(m.marked_range, rate, "caption marker marked_range");
+    const text =
+      typeof capcut.text === "string" && capcut.text ? capcut.text : typeof m.name === "string" ? m.name : "";
+    if (!text) {
+      skipped.push({ track: "(timeline)", type: "markers", reason: "a caption marker carries no text — skipped" });
+      continue;
+    }
+    captions.push({
+      text,
+      startUs: range.startUs,
+      durationUs: Math.max(1, range.durationUs),
+      track: typeof capcut.track === "string" && capcut.track ? capcut.track : "captions",
+    });
+  }
+  if (foreign > 0) {
+    skipped.push({
+      track: "(timeline)",
+      type: "markers",
+      reason: `${foreign} timeline marker(s) without capcut caption metadata have no CapCut equivalent`,
+    });
+  }
+  return captions;
 }
 
 function schemaOf(node: unknown): string {
@@ -318,6 +414,7 @@ export function otioToImportPlan(doc: unknown): ImportPlan {
     tracks: [],
     clips: 0,
     gaps: 0,
+    captions: captionsFromStackMarkers((stack as OtioObject).markers, rate, skipped),
     skipped,
   };
 
@@ -380,8 +477,9 @@ export function otioToImportPlan(doc: unknown): ImportPlan {
   return plan;
 }
 
-export function draftToOtio(draft: Draft): { doc: OtioObject; stats: OtioStats } {
+export function draftToOtio(draft: Draft, options: OtioExportOptions = {}): { doc: OtioObject; stats: OtioStats } {
   const rate = typeof draft.fps === "number" && draft.fps > 0 ? draft.fps : 30;
+  const captionMode = options.captions ?? "skip";
   // Issue #82: this used to be a local `Math.round((us / 1e6) * rate)`, a second
   // frame grid alongside time.ts. It differed in two ways that both reached the
   // exported file: a clip shorter than half a frame rounded to a zero-length OTIO
@@ -391,17 +489,37 @@ export function draftToOtio(draft: Draft): { doc: OtioObject; stats: OtioStats }
   const toFrames = (us: number) => framesFor(us, rate);
 
   const children: OtioObject[] = [];
-  const stats: OtioStats = { tracks: 0, clips: 0, gaps: 0, skipped: [] };
+  const stackMarkers: OtioObject[] = [];
+  const stats: OtioStats = { tracks: 0, clips: 0, gaps: 0, captions: 0, skipped: [] };
 
   for (const track of draft.tracks) {
     const kind = EXPORTABLE_TRACK_KINDS[track.type];
     if (!kind) {
+      if (track.type === "text" && captionMode === "markers") {
+        const segments = [...track.segments].sort((a, b) => a.target_timerange.start - b.target_timerange.start);
+        for (const segment of segments) {
+          const material = (draft.materials.texts ?? []).find((m) => m.id === segment.material_id);
+          const text = material && typeof material.content === "string" ? extractText(material.content) : "";
+          if (!text) continue;
+          stackMarkers.push(
+            captionMarker(
+              text,
+              toFrames(segment.target_timerange.start),
+              Math.max(1, toFrames(segment.target_timerange.duration)),
+              rate,
+              { track: track.name, track_id: track.id, segment_id: segment.id, material_id: segment.material_id },
+            ),
+          );
+          stats.captions++;
+        }
+        continue;
+      }
       stats.skipped.push({
         track: track.name,
         type: track.type,
         reason:
           track.type === "text"
-            ? "OTIO has no standard title schema — export captions with `capcut export-srt` and re-attach them in the NLE"
+            ? "OTIO has no standard title schema — pass --captions markers to carry cues as timeline markers, or export them with `capcut export-srt` and re-attach them in the NLE"
             : "no portable OTIO equivalent for this track type",
       });
       continue;
@@ -451,7 +569,7 @@ export function draftToOtio(draft: Draft): { doc: OtioObject; stats: OtioStats }
       OTIO_SCHEMA: "Stack.1",
       children,
       effects: [],
-      markers: [],
+      markers: stackMarkers,
       metadata: {},
       name: "tracks",
       source_range: null,

--- a/src/interchange.ts
+++ b/src/interchange.ts
@@ -247,7 +247,7 @@ function captionsFromStackMarkers(markers: unknown, rate: number, skipped: OtioS
   for (const marker of markers) {
     const m = marker as OtioObject;
     const capcut = (m.metadata as { capcut?: Record<string, unknown> } | undefined)?.capcut;
-    if (!capcut || capcut.kind !== "caption") {
+    if (capcut?.kind !== "caption") {
       foreign++;
       continue;
     }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -616,14 +616,14 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
     }
   }
 
-  // Unregistered-media sidecar note (pyCapCut#13), observe-only: newer builds
-  // (reported on CapCut International 9.1.0, macOS) show timeline media as
-  // "file inaccessible" and prompt per-clip relinking when
-  // draft_meta_info.json's draft_materials registers nothing. The registration
-  // WRITE stays deliberately out of scope until a real entry shape is captured
-  // (src/store.ts rationale) — so this is info-severity: it names the hazard
-  // where CI pipelines will actually see it and asks for the one artifact the
-  // write can be built from. It can never fail an exit code.
+  // Unregistered-media sidecar note (pyCapCut#13): newer builds (reported on
+  // CapCut International 9.1.0, macOS) show timeline media as "file
+  // inaccessible" and prompt per-clip relinking when draft_meta_info.json's
+  // draft_materials registers nothing. The repair is `capcut register
+  // <project> --materials --apply` (src/materials-register.ts) — a sidecar
+  // write, which lint --fix (a timeline-file repair) does not perform, so the
+  // issue stays fixable:false and names the command. Info-severity: it can
+  // never fail an exit code.
   // Gated on media that actually exists on disk: absent media is
   // missing-file's finding, and the 9.1.0 symptom is precisely media that IS
   // there and still shows inaccessible in the app.
@@ -644,7 +644,7 @@ export function lintDraft(draft: Draft, opts: LintOptions = DEFAULT_LINT_OPTIONS
         code: "media-unregistered",
         message: registration.note,
         fixable: false,
-        suggested_command: `capcut fixture ${opts.draftDir} --out <dir>`,
+        suggested_command: `capcut register ${opts.draftDir} --materials --apply`,
       });
     }
   }

--- a/src/materials-register.ts
+++ b/src/materials-register.ts
@@ -1,0 +1,285 @@
+// `register --materials` — the draft_materials registration write.
+//
+// The symptom (GuanYixuan/pyCapCut#13, CapCut International 9.1.0 on macOS):
+// the app decides which media has actually been IMPORTED from
+// draft_meta_info.json's `draft_materials`, not from the timeline's material
+// paths. A sidecar whose groups are all empty — every tool-built draft, this
+// CLI's included — opens with each clip shown as "file inaccessible" and a
+// relink prompt, even though every `path` in draft_content.json is valid and
+// the files exist. v0.21 taught `lint` and `diagnose` to observe the empty
+// state (`media-unregistered`); this module writes the registration.
+//
+// Entry shape and its provenance: pyCapCut PR #14 (gingatimo, 2026-08-18),
+// which registers timeline media into the type-0 group after every save and
+// was verified by its author against the 9.1.0 relink prompt. The app matches
+// entries to timeline materials by `file_Path`; the remaining fields carry the
+// defaults CapCut writes for a manual import (`import_time: -1`, `md5: ""`,
+// `item_source: 1`). Photos register with a 5 s nominal duration, audio with
+// `metetype: "music"` and zero dimensions — again the PR's tested values. No
+// app-authored 9.1 sidecar is committed here yet; `capcut fixture` on one
+// would let the shape be confirmed byte-for-byte, and the schema docs record
+// the source so the next reader knows what is measured and what is inferred.
+//
+// Write discipline (register's): merge, never replace. Existing entries — the
+// app's own, from a draft it imported media into — are preserved untouched;
+// only media the sidecar does not register is appended, one entry per distinct
+// path, into the type-0 group (created when absent). Re-running is a no-op.
+
+import { randomUUID } from "node:crypto";
+import { basename, isAbsolute, resolve } from "node:path";
+import type { Draft } from "./draft.js";
+
+export type MetaMaterialKind = "video" | "photo" | "music";
+
+/** draft_materials[type=0].value[] entry — field order follows CapCut's own sidecar. */
+export interface MetaMaterialEntry {
+  ai_group_type: string;
+  create_time: number;
+  duration: number;
+  enter_from: number;
+  extra_info: string;
+  file_Path: string;
+  height: number;
+  id: string;
+  import_time: number;
+  import_time_ms: number;
+  item_source: number;
+  material_color_tag: string;
+  md5: string;
+  metetype: MetaMaterialKind;
+  roughcut_time_range: { duration: number; start: number };
+  sub_time_range: { duration: number; start: number };
+  type: number;
+  width: number;
+}
+
+/** Nominal duration CapCut records for an imported still image (pyCapCut PR #14). */
+export const PHOTO_META_DURATION_US = 5_000_000;
+
+/** The group `type` that holds imported media in `draft_materials`. */
+export const IMPORTED_MEDIA_GROUP_TYPE = 0;
+
+export interface ReferencedMedium {
+  path: string;
+  name: string;
+  kind: MetaMaterialKind;
+  durationUs: number;
+  width: number;
+  height: number;
+}
+
+export function buildMetaMaterialEntry(medium: ReferencedMedium): MetaMaterialEntry {
+  const duration = medium.durationUs > 0 ? Math.round(medium.durationUs) : PHOTO_META_DURATION_US;
+  return {
+    ai_group_type: "",
+    create_time: -1,
+    duration,
+    enter_from: 0,
+    extra_info: medium.name,
+    file_Path: medium.path,
+    height: medium.kind === "music" ? 0 : Math.round(medium.height || 0),
+    id: randomUUID(),
+    import_time: -1,
+    import_time_ms: -1,
+    item_source: 1,
+    material_color_tag: "",
+    md5: "",
+    metetype: medium.kind,
+    roughcut_time_range: { duration: -1, start: -1 },
+    sub_time_range: { duration: -1, start: -1 },
+    type: 0,
+    width: medium.kind === "music" ? 0 : Math.round(medium.width || 0),
+  };
+}
+
+function isLocalPath(path: unknown): path is string {
+  return typeof path === "string" && path.length > 0 && !/^https?:\/\//i.test(path);
+}
+
+/**
+ * Distinct local media the timeline references, in material order: video and
+ * photo materials from `materials.videos`, audio from `materials.audios`. URLs
+ * (Wikimedia adds resolve to local copies anyway) are skipped, and one file
+ * referenced by several materials is one medium to register.
+ */
+export function referencedMedia(draft: Draft): ReferencedMedium[] {
+  const seen = new Set<string>();
+  const out: ReferencedMedium[] = [];
+  for (const mat of draft.materials.videos ?? []) {
+    const m = mat as Record<string, unknown>;
+    if (!isLocalPath(m.path) || seen.has(m.path)) continue;
+    seen.add(m.path);
+    const photo = m.type === "photo";
+    out.push({
+      path: m.path,
+      name: typeof m.material_name === "string" && m.material_name !== "" ? m.material_name : basename(m.path),
+      kind: photo ? "photo" : "video",
+      durationUs: photo ? PHOTO_META_DURATION_US : typeof m.duration === "number" ? m.duration : 0,
+      width: typeof m.width === "number" ? m.width : 0,
+      height: typeof m.height === "number" ? m.height : 0,
+    });
+  }
+  for (const mat of draft.materials.audios ?? []) {
+    const m = mat as Record<string, unknown>;
+    if (!isLocalPath(m.path) || seen.has(m.path)) continue;
+    seen.add(m.path);
+    out.push({
+      path: m.path,
+      name: typeof m.name === "string" && m.name !== "" ? m.name : basename(m.path),
+      kind: "music",
+      durationUs: typeof m.duration === "number" ? m.duration : 0,
+      width: 0,
+      height: 0,
+    });
+  }
+  return out;
+}
+
+export interface MaterialsRegistrationTarget {
+  file: "draft_meta_info.json";
+  field: "draft_materials";
+  path: string;
+  state: "ok" | "no-media" | "unregistered" | "sidecar-unavailable";
+  action: "none" | "update" | "blocked";
+  detail: string;
+  /** Distinct local media files the timeline references. */
+  referenced: number;
+  /** Of those, already present in draft_materials (matched by file_Path). */
+  registered: number;
+  /** Paths this plan registers (empty when nothing is missing). */
+  to_register: string[];
+  /** Entries already in the sidecar that no timeline material references — preserved, never removed. */
+  unreferenced_entries: number;
+}
+
+function normalise(path: string, projectDir: string): string {
+  return isAbsolute(path) ? resolve(path) : resolve(projectDir, path);
+}
+
+/** Every file_Path already registered across ALL groups (the app may have put media in a non-zero group). */
+function registeredPaths(groups: unknown): string[] {
+  const paths: string[] = [];
+  const collect = (value: unknown): void => {
+    if (!Array.isArray(value)) return;
+    for (const entry of value) {
+      if (entry && typeof entry === "object" && typeof (entry as Record<string, unknown>).file_Path === "string") {
+        paths.push((entry as Record<string, unknown>).file_Path as string);
+      }
+    }
+  };
+  if (Array.isArray(groups)) {
+    for (const group of groups) {
+      if (group && typeof group === "object" && !Array.isArray(group))
+        collect((group as Record<string, unknown>).value);
+    }
+  } else if (groups && typeof groups === "object") {
+    for (const value of Object.values(groups)) collect(value);
+  }
+  return paths;
+}
+
+/**
+ * Plan the draft_materials registration against a parsed sidecar object (the
+ * one on disk, or the one `register`'s own sidecar repair is about to write —
+ * so a missing/corrupt sidecar and its media registration land in ONE write).
+ * `sidecar === null` means no readable sidecar exists and none is planned:
+ * blocked, with the register step that unblocks it named in `detail`.
+ * Returns the repaired sidecar object when there is something to write.
+ */
+export function planDraftMaterials(
+  draft: Draft,
+  sidecar: Record<string, unknown> | null,
+  options: { sidecarPath: string; projectDir: string },
+): { target: MaterialsRegistrationTarget; fixed: Record<string, unknown> | null } {
+  const media = referencedMedia(draft);
+  const base = {
+    file: "draft_meta_info.json" as const,
+    field: "draft_materials" as const,
+    path: options.sidecarPath,
+    referenced: media.length,
+  };
+  if (media.length === 0) {
+    return {
+      target: {
+        ...base,
+        state: "no-media",
+        action: "none",
+        detail: "the timeline references no local media, so there is nothing to register",
+        registered: 0,
+        to_register: [],
+        unreferenced_entries: 0,
+      },
+      fixed: null,
+    };
+  }
+  if (sidecar === null) {
+    return {
+      target: {
+        ...base,
+        state: "sidecar-unavailable",
+        action: "blocked",
+        detail:
+          "draft_meta_info.json is missing or unreadable and this run does not recreate it; " +
+          "run `capcut register <project> --apply` (which recreates the sidecar) together with --materials",
+        registered: 0,
+        to_register: media.map((m) => m.path),
+        unreferenced_entries: 0,
+      },
+      fixed: null,
+    };
+  }
+
+  const existing = registeredPaths(sidecar.draft_materials);
+  const existingNormalised = new Set(existing.map((p) => normalise(p, options.projectDir)));
+  const referencedNormalised = new Set(media.map((m) => normalise(m.path, options.projectDir)));
+  const missing = media.filter((m) => !existingNormalised.has(normalise(m.path, options.projectDir)));
+  const unreferenced = existing.filter((p) => !referencedNormalised.has(normalise(p, options.projectDir))).length;
+
+  if (missing.length === 0) {
+    return {
+      target: {
+        ...base,
+        state: "ok",
+        action: "none",
+        detail: `every referenced media file (${media.length}) is registered in draft_materials`,
+        registered: media.length,
+        to_register: [],
+        unreferenced_entries: unreferenced,
+      },
+      fixed: null,
+    };
+  }
+
+  // Merge into the type-0 group, creating the group (and the array) when the
+  // sidecar carries no usable draft_materials; other groups and every existing
+  // entry are preserved as they are.
+  const fixed = structuredClone(sidecar);
+  const groupsRaw = fixed.draft_materials;
+  const groups: Array<Record<string, unknown>> = Array.isArray(groupsRaw)
+    ? (groupsRaw.filter((g) => g && typeof g === "object" && !Array.isArray(g)) as Array<Record<string, unknown>>)
+    : [];
+  let group0 = groups.find((g) => g.type === IMPORTED_MEDIA_GROUP_TYPE);
+  if (!group0) {
+    group0 = { type: IMPORTED_MEDIA_GROUP_TYPE, value: [] };
+    groups.unshift(group0);
+  }
+  if (!Array.isArray(group0.value)) group0.value = [];
+  for (const medium of missing) (group0.value as unknown[]).push(buildMetaMaterialEntry(medium));
+  fixed.draft_materials = groups;
+
+  return {
+    target: {
+      ...base,
+      state: "unregistered",
+      action: "update",
+      detail:
+        `${missing.length} of ${media.length} referenced media file(s) are not registered in draft_materials ` +
+        `(CapCut 9.1 shows them as "file inaccessible"); entries will be appended to the type-0 group, ` +
+        `existing entries preserved`,
+      registered: media.length - missing.length,
+      to_register: missing.map((m) => m.path),
+      unreferenced_entries: unreferenced,
+    },
+    fixed,
+  };
+}

--- a/src/matting.ts
+++ b/src/matting.ts
@@ -1,0 +1,127 @@
+// Smart matting — "Remove background" in CapCut, 智能抠像 in JianYing — is a
+// property of the VIDEO MATERIAL, not the segment: `materials.videos[].matting`.
+//
+// Ground truth, and its provenance:
+// - The OFF shape is the object every app-authored video material carries
+//   (docs/draft-schema/02-materials.md): `{ flag: 0, has_use_quick_brush: false,
+//   interactiveTime: [], path: "", strokes: [] }`. CLI-created materials
+//   (add-video, compile) have never written the key at all — the app tolerates
+//   both, so `matting --off` writes the documented object rather than deleting.
+// - The ON shape comes from the pyJianYingDraft contributor PRs #183/#184
+//   (KyonXuu, 2026-05): `flag: 3` is "smart portrait matting"; `path` is the
+//   app's matting cache and `strokes`/`interactiveTime` are the manual
+//   brush/eraser corrections, all of which the app fills in itself on first
+//   open. A fresh request therefore writes flag 3 and leaves every cache field
+//   at its empty default — exactly the PR's `add_smart_matting()` default. Newer
+//   builds also carry `has_use_quick_eraser`; it is written alongside the brush
+//   flag so the object matches what those builds emit.
+//
+// Neither PR merged and no app-authored flag-3 fixture is committed here, so
+// this is an evidence-gated write in the same sense as the rest of the schema
+// docs: the shape is recorded with its source, and `fixture` will capture the
+// real thing the moment a matted app draft is shared.
+
+import type { Draft, MaterialVideo, Segment } from "./draft.js";
+import { findSegment } from "./draft.js";
+
+export const MATTING_OFF = 0;
+export const MATTING_SMART_PORTRAIT = 3;
+
+export interface MattingObject {
+  flag: number;
+  has_use_quick_brush: boolean;
+  has_use_quick_eraser: boolean;
+  interactiveTime: unknown[];
+  path: string;
+  strokes: unknown[];
+  [key: string]: unknown;
+}
+
+export interface MattingResult {
+  ok: true;
+  segmentId: string;
+  materialId: string;
+  flag: number;
+  enabled: boolean;
+  /** Other segments that reference the same material — matting is per material, so they change too. */
+  shared_segments: string[];
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * The matting object with `flag` set. Existing cache fields (the app's `path`,
+ * brush strokes) are preserved so toggling never destroys app-authored state;
+ * missing fields are filled from the documented off-shape defaults.
+ */
+export function mattingObject(flag: number, existing?: unknown): MattingObject {
+  const current = isRecord(existing) ? existing : {};
+  return {
+    has_use_quick_brush: false,
+    has_use_quick_eraser: false,
+    interactiveTime: [],
+    path: "",
+    strokes: [],
+    ...current,
+    flag,
+  };
+}
+
+function resolveVideoMaterial(
+  draft: Draft,
+  segId: string,
+): { segment: Segment; material: MaterialVideo; shared: string[] } {
+  const found = findSegment(draft, segId);
+  if (!found) throw new Error(`Segment not found: ${segId}`);
+  if (found.track.type !== "video") {
+    throw new Error(
+      `Smart matting only applies to video/photo segments (segment ${segId} is on a ${found.track.type} track)`,
+    );
+  }
+  const material = (draft.materials.videos ?? []).find((m) => m.id === found.segment.material_id);
+  if (!material) throw new Error(`Segment ${segId} references a missing video material: ${found.segment.material_id}`);
+  const shared: string[] = [];
+  for (const track of draft.tracks) {
+    for (const seg of track.segments) {
+      if (seg.id !== found.segment.id && seg.material_id === material.id) shared.push(seg.id);
+    }
+  }
+  return { segment: found.segment, material, shared };
+}
+
+/** Turn smart portrait matting on for the segment's video material. */
+export function setMatting(draft: Draft, segId: string): MattingResult {
+  const { segment, material, shared } = resolveVideoMaterial(draft, segId);
+  material.matting = mattingObject(MATTING_SMART_PORTRAIT, material.matting);
+  return {
+    ok: true,
+    segmentId: segment.id,
+    materialId: material.id,
+    flag: MATTING_SMART_PORTRAIT,
+    enabled: true,
+    shared_segments: shared,
+  };
+}
+
+/** Turn matting off, writing the documented flag-0 object (cache fields kept). */
+export function clearMatting(draft: Draft, segId: string): MattingResult {
+  const { segment, material, shared } = resolveVideoMaterial(draft, segId);
+  material.matting = mattingObject(MATTING_OFF, material.matting);
+  return {
+    ok: true,
+    segmentId: segment.id,
+    materialId: material.id,
+    flag: MATTING_OFF,
+    enabled: false,
+    shared_segments: shared,
+  };
+}
+
+/** Read the matting state of a segment's material without writing. */
+export function mattingState(draft: Draft, segId: string): { segmentId: string; materialId: string; flag: number } {
+  const { segment, material } = resolveVideoMaterial(draft, segId);
+  const flag = isRecord(material.matting) && typeof material.matting.flag === "number" ? material.matting.flag : 0;
+  return { segmentId: segment.id, materialId: material.id, flag };
+}

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -8,7 +8,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { stripBom } from "./bom.js";
 import { loadDraft, saveDraft } from "./draft.js";
-import { addAudio, addText, addVideo, initDraft } from "./factory.js";
+import { addAudio, addText, addVideo, type CanvasConfig, initDraft } from "./factory.js";
 import { lintDraft, summarize } from "./lint.js";
 import { probeMedia } from "./probe.js";
 import { parseSrt } from "./srt.js";
@@ -29,6 +29,8 @@ export interface QuickstartOptions {
   srt?: string;
   ffprobeCmd?: string;
   now?: number;
+  /** Canvas override from --ratio / --width / --height (factory.resolveCanvas); template canvas when absent. */
+  canvas?: CanvasConfig;
 }
 
 export interface QuickstartStep {
@@ -43,6 +45,7 @@ export interface QuickstartResult {
   draft_path: string;
   file_path: string;
   registered: boolean;
+  canvas: CanvasConfig | null;
   added: { video: boolean; audio: boolean; captions: number };
   steps: QuickstartStep[];
   lint: { errors: number; warnings: number; info: number; total: number };
@@ -83,13 +86,16 @@ export function runQuickstart(opts: QuickstartOptions): QuickstartResult {
     templateDir: opts.templateDir,
     draftsDir: opts.draftsDir,
     now: opts.now,
+    canvas: opts.canvas,
   });
+  const canvasNote = init.canvas ? ` Canvas ${init.canvas.width}x${init.canvas.height} (${init.canvas.ratio}).` : "";
   steps.push({
     step: "create",
     ok: true,
-    detail: init.registered
-      ? "Draft created and registered in CapCut's project index."
-      : "Draft created (could not update root_meta_info.json — may not be listed).",
+    detail:
+      (init.registered
+        ? "Draft created and registered in CapCut's project index."
+        : "Draft created (could not update root_meta_info.json — may not be listed).") + canvasNote,
   });
 
   const { draft, filePath } = loadDraft(init.draftPath);
@@ -154,6 +160,7 @@ export function runQuickstart(opts: QuickstartOptions): QuickstartResult {
     draft_path: init.draftPath,
     file_path: filePath,
     registered: init.registered,
+    canvas: init.canvas,
     added,
     steps,
     lint,

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, extname, join } from "node:path";
 import type { Draft, Segment } from "./draft.js";
 import { extractText } from "./draft.js";
+import { renderSrt } from "./srt.js";
 
 /**
  * Headless ffmpeg proxy renderer.
@@ -31,9 +32,37 @@ export interface RenderOptions {
   ffmpegCmd?: string; // ffmpeg binary (default "ffmpeg")
   encoder?: string; // -c:v video encoder (default libx264; e.g. h264_videotoolbox/h264_nvenc/h264_qsv)
   burnCaptions?: boolean; // draw text-track segments onto the video
+  softCaptions?: boolean; // mux the text-track cues as a mov_text subtitle stream (see softCaptionsFor)
   allVideoTracks?: boolean; // composite overlay video tracks
   dryRun?: boolean; // build the plan, do not execute ffmpeg
   progress?: boolean; // stream ffmpeg's own stderr instead of buffering it
+}
+
+/**
+ * `--soft-captions`: reviewers asked for subtitle STREAMS they can toggle in
+ * the player rather than pixels burned into the proxy (munim-ffmpeg#3,
+ * home-os#86 — "soft subtitle muxing" in ffmpeg terms). The text-track cues
+ * are rendered to an SRT beside the output (`<preview>.srt`, which most
+ * players auto-load by name anyway) and muxed as an mp4 `mov_text` stream.
+ * Two ffmpeg facts shape the plan: mov_text is an encoder some minimal builds
+ * lack (probed; skipped with a note, like drawtext), and `-shortest` treats
+ * the subtitle stream as a stream — the file would end at the last cue — so
+ * the plan drops `-shortest` when a subtitle stream is muxed (the video and
+ * audio chains are already bounded by their trims, photos by `-t`).
+ */
+export interface SoftCaptionsPlan {
+  /** Where the SRT is written before ffmpeg runs (next to the output). */
+  path: string;
+  /** SRT content, one cue per text segment with text. */
+  srt: string;
+  cues: number;
+  /** Input index the SRT occupies in the ffmpeg invocation. */
+  inputIndex: number;
+}
+
+export function srtPathFor(output: string): string {
+  const ext = extname(output);
+  return ext ? `${output.slice(0, -ext.length)}.srt` : `${output}.srt`;
 }
 
 const RENDER_TIMEOUT_MS = 600_000;
@@ -98,7 +127,7 @@ export function explainFfmpegFailure(stderr: string): string {
 export interface RenderInput {
   index: number;
   path: string;
-  kind: "video" | "photo" | "audio";
+  kind: "video" | "photo" | "audio" | "subtitle";
 }
 
 export interface RenderPlan {
@@ -115,6 +144,8 @@ export interface RenderPlan {
   skipped: Array<{ segmentId: string; reason: string }>;
   overlaySegments: number;
   capabilities?: FfmpegCapabilities;
+  /** Present only with --soft-captions and at least one cue. */
+  softCaptions?: SoftCaptionsPlan;
 }
 
 export interface RenderResult extends RenderPlan {
@@ -579,6 +610,25 @@ export function buildRenderPlan(draft: Draft, opts: RenderOptions): RenderPlan {
     filterParts.push(`${audioLabels.join("")}amix=inputs=${audioLabels.length}:normalize=0[${aOut}]`);
   }
 
+  // --- soft captions (optional): SRT input + mov_text stream ---
+  let softCaptions: SoftCaptionsPlan | undefined;
+  if (opts.softCaptions) {
+    const cues = textSegments(draft).map(({ seg, text }) => ({
+      startUs: seg.target_timerange.start,
+      endUs: seg.target_timerange.start + seg.target_timerange.duration,
+      text,
+    }));
+    if (cues.length === 0) {
+      skipped.push({ segmentId: "captions", reason: "no text segments to mux as soft captions" });
+    } else {
+      const srtPath = srtPathFor(output);
+      const inputIndex = inputs.length;
+      inputs.push({ index: inputIndex, path: srtPath, kind: "subtitle" });
+      inputArgs.push("-i", srtPath);
+      softCaptions = { path: srtPath, srt: renderSrt(cues), cues: cues.length, inputIndex };
+    }
+  }
+
   const filterComplex = filterParts.join(";");
   const args = [
     "-y",
@@ -588,6 +638,7 @@ export function buildRenderPlan(draft: Draft, opts: RenderOptions): RenderPlan {
     "-map",
     `[${vOut}]`,
     ...(aOut ? ["-map", `[${aOut}]`] : []),
+    ...(softCaptions ? ["-map", `${softCaptions.inputIndex}:0`] : []),
     "-c:v",
     opts.encoder ?? "libx264",
     "-preset",
@@ -597,7 +648,7 @@ export function buildRenderPlan(draft: Draft, opts: RenderOptions): RenderPlan {
     "-pix_fmt",
     "yuv420p",
     ...(aOut ? ["-c:a", "aac", "-b:a", "128k"] : ["-an"]),
-    "-shortest",
+    ...(softCaptions ? ["-c:s", "mov_text", "-metadata:s:s:0", "language=und"] : ["-shortest"]),
     output,
   ];
 
@@ -614,6 +665,7 @@ export function buildRenderPlan(draft: Draft, opts: RenderOptions): RenderPlan {
     textOverlays,
     overlaySegments,
     skipped,
+    ...(softCaptions ? { softCaptions } : {}),
   };
 }
 
@@ -666,6 +718,19 @@ export function renderDraft(draft: Draft, filePath: string, opts: RenderOptions)
     effective.allVideoTracks = false;
     fallbackSkipped.push({ segmentId: "overlays", reason: "ffmpeg lacks overlay filter; extra video tracks disabled" });
   }
+  if (effective.softCaptions) {
+    // Same shape as the drawtext fallback: an optional extra is withheld with
+    // a note rather than failing the render. Only a build that LISTS its
+    // encoders and lacks mov_text is treated as lacking it.
+    const { listed, encoders } = probeFfmpegEncoders(opts.ffmpegCmd ?? "ffmpeg");
+    if (listed && !encoders.has("mov_text")) {
+      effective.softCaptions = false;
+      fallbackSkipped.push({
+        segmentId: "captions",
+        reason: "ffmpeg lacks the mov_text encoder; soft captions disabled",
+      });
+    }
+  }
   const basePlan = buildRenderPlan(draft, effective);
   const plan = { ...basePlan, capabilities, skipped: [...basePlan.skipped, ...fallbackSkipped] };
 
@@ -687,6 +752,10 @@ export function renderDraft(draft: Draft, filePath: string, opts: RenderOptions)
   if (opts.dryRun) {
     return { ...plan, ok: true, executed: false };
   }
+
+  // The SRT must exist before ffmpeg opens its inputs; it stays next to the
+  // output afterwards (players auto-load a same-named .srt).
+  if (plan.softCaptions) writeFileSync(plan.softCaptions.path, plan.softCaptions.srt, "utf-8");
 
   const cmd = opts.ffmpegCmd ?? "ffmpeg";
   // --progress hands ffmpeg's stderr straight to the terminal. That is both the

--- a/src/retakes.ts
+++ b/src/retakes.ts
@@ -1,0 +1,196 @@
+// Retake detection (`detect-retakes`).
+//
+// A talking-head recording is full of second attempts: the speaker fluffs a
+// sentence, pauses, and says it again. Silence detection finds the pause;
+// nothing in the cut pipeline found the REPEAT, so the earlier attempt stayed
+// in the timeline unless someone scrubbed for it. The one tool in the
+// ecosystem that did try (mrbuslov/capcut-ai-editor, PR #3, 2026-08-07) shows
+// the failure mode to design against: its sentence-similarity pass matched
+// unrelated sentences 27 minutes apart and collapsed a 29-minute recording to
+// 1:47. Hence the three guards here, all explicit parameters:
+//
+//   - a WINDOW: a candidate later take must start within N seconds of the
+//     earlier one ending (default 60 s — nobody re-records a sentence half an
+//     hour later);
+//   - a MINIMUM LENGTH: cues shorter than N words never count (default 4 —
+//     "yeah", "okay so" repeat constantly and are not retakes);
+//   - a SIMILARITY floor on the normalised word sequences (default 0.8 of the
+//     Ratcliff/Obershelp-style ratio 2·LCS/(|a|+|b|)), so a genuinely
+//     rephrased sentence is not mistaken for a repeat.
+//
+// Convention: the LATER take is the keeper (that is why it was re-recorded);
+// the earlier cue's span becomes a cut. Output mirrors detect-silence — cut
+// spans plus the complementary keep spans, in seconds and microseconds — so
+// the same `cut` / `compile` step consumes it. Pure and deterministic.
+
+import { normalizeToken } from "./align.js";
+import type { SceneSegment } from "./scenes.js";
+import { buildKeepSpans, type SilenceSpan, spansToSegments } from "./silence.js";
+
+const US = 1_000_000;
+
+export interface RetakeCue {
+  text: string;
+  startUs: number;
+  endUs: number;
+}
+
+export interface RetakeOptions {
+  /** Max gap between the earlier cue's end and the later cue's start, seconds (default 60). */
+  window?: number;
+  /** Similarity floor on the normalised word sequences, 0..1 (default 0.8). */
+  similarity?: number;
+  /** Cues with fewer normalised words never count as a take (default 4). */
+  minWords?: number;
+}
+
+export interface RetakeSide {
+  text: string;
+  start: number;
+  end: number;
+  start_us: number;
+  end_us: number;
+}
+
+export interface RetakePair {
+  earlier: RetakeSide;
+  later: RetakeSide;
+  similarity: number;
+  /** Normalised word count of the earlier cue. */
+  words: number;
+}
+
+export interface RetakeReport {
+  source: string;
+  window: number;
+  similarity: number;
+  min_words: number;
+  cues: number;
+  duration: number | null;
+  duration_us: number | null;
+  retakes: RetakePair[];
+  /** Spans to drop: the earlier take of every pair, merged where they touch. */
+  cuts: SceneSegment[];
+  /** Everything else, over [0, duration] — what `cut`/`compile` keeps. */
+  keeps: SceneSegment[];
+}
+
+/** Words of a cue in comparison form (empty tokens removed). */
+export function normalizeWords(text: string): string[] {
+  return text
+    .split(/\s+/)
+    .map(normalizeToken)
+    .filter((t) => t.length > 0);
+}
+
+/** Longest common subsequence length of two token arrays. */
+function lcsLength(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  let prev = new Uint16Array(b.length + 1);
+  let cur = new Uint16Array(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = a[i - 1] === b[j - 1] ? prev[j - 1] + 1 : Math.max(prev[j], cur[j - 1]);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[b.length];
+}
+
+/** 2·LCS/(|a|+|b|): 1 for identical sequences, 0 for nothing in common. */
+export function sequenceSimilarity(a: string[], b: string[]): number {
+  if (a.length + b.length === 0) return 0;
+  return Math.round(((2 * lcsLength(a, b)) / (a.length + b.length)) * 1000) / 1000;
+}
+
+function side(cue: RetakeCue): RetakeSide {
+  return {
+    text: cue.text,
+    start: round6(cue.startUs / US),
+    end: round6(cue.endUs / US),
+    start_us: cue.startUs,
+    end_us: cue.endUs,
+  };
+}
+
+function round6(n: number): number {
+  return Math.round(n * 1_000_000) / 1_000_000;
+}
+
+/**
+ * Find retake pairs among time-ordered cues. Each earlier cue is compared with
+ * the later cues that start inside the window; the FIRST later cue that
+ * clears the similarity floor is its retake (closest repeat wins). A cue that
+ * is itself the later half of one pair can still be the earlier half of the
+ * next — three attempts at one sentence yield two pairs and keep the last.
+ */
+export function findRetakes(cues: RetakeCue[], opts: RetakeOptions = {}): RetakePair[] {
+  const windowUs = Math.round((opts.window ?? 60) * US);
+  const floor = opts.similarity ?? 0.8;
+  const minWords = opts.minWords ?? 4;
+  const ordered = [...cues].sort((a, b) => a.startUs - b.startUs);
+  const tokens = ordered.map((c) => normalizeWords(c.text));
+  const pairs: RetakePair[] = [];
+  for (let i = 0; i < ordered.length; i++) {
+    if (tokens[i].length < minWords) continue;
+    for (let j = i + 1; j < ordered.length; j++) {
+      if (ordered[j].startUs - ordered[i].endUs > windowUs) break;
+      if (tokens[j].length < minWords) continue;
+      const sim = sequenceSimilarity(tokens[i], tokens[j]);
+      if (sim >= floor) {
+        pairs.push({ earlier: side(ordered[i]), later: side(ordered[j]), similarity: sim, words: tokens[i].length });
+        break;
+      }
+    }
+  }
+  return pairs;
+}
+
+/** Merge touching/overlapping spans, in time order. */
+export function mergeSpans(spans: SilenceSpan[]): SilenceSpan[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  const merged: SilenceSpan[] = [];
+  for (const span of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && last.end !== null && span.start <= last.end) {
+      if (span.end === null || (last.end !== null && span.end > last.end)) last.end = span.end;
+    } else {
+      merged.push({ start: span.start, end: span.end });
+    }
+  }
+  return merged;
+}
+
+/**
+ * The full report: pairs, the cut spans (earlier takes, merged) and the keep
+ * spans over [0, duration]. `durationUs` null → the last cue's end bounds the
+ * keeps (open-ended like detect-silence without a probe would be misleading
+ * here: cues are timeline facts, not a stream probe).
+ */
+export function buildRetakeReport(
+  cues: RetakeCue[],
+  durationUs: number | null,
+  opts: RetakeOptions,
+  source: string,
+): RetakeReport {
+  const retakes = findRetakes(cues, opts);
+  const cuts = mergeSpans(retakes.map((p) => ({ start: p.earlier.start, end: p.earlier.end })));
+  const bound =
+    durationUs !== null && durationUs > 0
+      ? durationUs / US
+      : cues.length > 0
+        ? Math.max(...cues.map((c) => c.endUs)) / US
+        : 0;
+  return {
+    source,
+    window: opts.window ?? 60,
+    similarity: opts.similarity ?? 0.8,
+    min_words: opts.minWords ?? 4,
+    cues: cues.length,
+    duration: bound > 0 ? round6(bound) : null,
+    duration_us: bound > 0 ? Math.round(bound * US) : null,
+    retakes,
+    cuts: spansToSegments(cuts),
+    keeps: spansToSegments(buildKeepSpans(cuts, bound > 0 ? bound : null)),
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -964,12 +964,10 @@ function draftMaterialsAllEmpty(value: unknown): boolean {
  * on CapCut International 9.1.0, macOS) are reported to show timeline media as
  * "file inaccessible" and prompt per-clip relinking when draft_meta_info.json's
  * `draft_materials` does not register the media, even with valid paths in
- * draft_content.json. This CLI never writes `draft_materials` and the entry
- * shape has never been captured from a real draft, so the registration write
- * is deliberately out of scope — diagnose only observes and asks for the one
- * artifact it can be built from. Null (no note) whenever the timeline
- * references no local media, the sidecar is unreadable, or `draft_materials`
- * is not provably empty.
+ * draft_content.json. diagnose observes; `register --materials` (v0.22,
+ * src/materials-register.ts) writes the registration from the pyCapCut PR #14
+ * entry shape. Null (no note) whenever the timeline references no local media,
+ * the sidecar is unreadable, or `draft_materials` is not provably empty.
  */
 function assessMediaRegistration(store: DraftStore): MediaRegistrationNote | null {
   const meta = store.candidates.find((candidate) => candidate.name === "draft_meta_info.json");
@@ -1018,10 +1016,10 @@ export function assessMediaRegistrationRaw(
       `${referenced} local media file(s) are referenced by the timeline, and ${observed}. ` +
       "Newer builds (reported on CapCut International 9.1.0, macOS) are reported to show such media as " +
       '"file inaccessible" and to prompt per-clip relinking even when the timeline file carries valid paths. ' +
-      "This CLI does not write `draft_materials` — no real entry shape has been captured yet. If you see that " +
-      "symptom: save a draft with the same media in the CapCut app itself on such a build, then run " +
-      "`capcut fixture <project> --out <dir>` on it. The sanitized bundle includes draft_meta_info.json and is " +
-      "the evidence a registration write can be built from.",
+      "Repair: `capcut register <project> --materials --apply` registers the referenced media in " +
+      "`draft_materials` (entry shape per pyCapCut PR #14, verified against the 9.1.0 prompt by its author). " +
+      "An app-authored sidecar from such a build is still welcome as ground truth: save a draft with the same " +
+      "media in the CapCut app, then run `capcut fixture <project> --out <dir>` on it.",
   };
 }
 

--- a/test/caption-script.test.mjs
+++ b/test/caption-script.test.mjs
@@ -14,6 +14,9 @@ import { tmpDraft } from "./helpers/tmp-draft.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FAKE_WHISPER = join(__dirname, "helpers", "fake-whisper.mjs");
+// spawnSync cannot execute a shebang script on Windows (same reason the other
+// fake-binary suites skip there); the alignment itself is asserted directly above.
+const isWindows = process.platform === "win32";
 
 function scratch() {
   const dir = mkdtempSync(join(tmpdir(), "capcut-caption-script-"));
@@ -127,7 +130,7 @@ describe("align.ts — transcript alignment", () => {
   });
 });
 
-describe("capcut caption --script (fake whisper)", () => {
+describe("capcut caption --script (fake whisper)", { skip: isWindows }, () => {
   it("one cue per script line with the script's wording and whisper's timing; reports the alignment", (t) => {
     const fix = tmpDraft();
     t.after(() => fix.cleanup());
@@ -271,7 +274,9 @@ describe("capcut caption --script (fake whisper)", () => {
     assert.equal(r.json.script, undefined);
     assert.equal(r.json.cues, 1);
   });
+});
 
+describe("caption --script surface", () => {
   it("describe lists --script on caption", () => {
     const r = spawnCli(["describe"]);
     const spec = r.json.commands.find((c) => c.name === "caption");

--- a/test/caption-script.test.mjs
+++ b/test/caption-script.test.mjs
@@ -1,0 +1,280 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { alignScript, normalizeToken, tokenizeScript } from "../dist/align.js";
+import { extractText } from "../dist/draft.js";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// `caption --script`: whisper's timing, the script's words. The alignment is
+// pure (asserted directly); the CLI path runs through a fake whisper binary.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FAKE_WHISPER = join(__dirname, "helpers", "fake-whisper.mjs");
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-caption-script-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+// Whisper "heard" this: chanel/ramarys are the classic mis-hearings.
+const HEARD_WORDS = [
+  { word: "welcome", start: 0.0, end: 0.4 },
+  { word: "to", start: 0.4, end: 0.5 },
+  { word: "the", start: 0.5, end: 0.6 },
+  { word: "chanel", start: 0.6, end: 1.0 },
+  { word: "today", start: 1.2, end: 1.5 },
+  { word: "we", start: 1.5, end: 1.6 },
+  { word: "talk", start: 1.6, end: 1.9 },
+  { word: "about", start: 1.9, end: 2.1 },
+  { word: "ramarys", start: 2.1, end: 2.7 },
+];
+const SCRIPT = "Welcome to the channel, today we talk about Ramaris.\nAnd the sidecar it writes.\n";
+
+function whisperJson() {
+  return JSON.stringify({
+    segments: [
+      {
+        start: 0,
+        end: 2.7,
+        text: HEARD_WORDS.map((w) => w.word).join(" "),
+        words: HEARD_WORDS.map((w) => ({ word: w.word, start: w.start, end: w.end })),
+      },
+    ],
+  });
+}
+
+function textCues(path) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  const cues = [];
+  for (const track of draft.tracks) {
+    if (track.type !== "text") continue;
+    for (const seg of track.segments) {
+      const mat = draft.materials.texts.find((m) => m.id === seg.material_id);
+      cues.push({
+        track: track.name,
+        text: extractText(mat.content),
+        start: seg.target_timerange.start,
+        end: seg.target_timerange.start + seg.target_timerange.duration,
+      });
+    }
+  }
+  return cues.sort((a, b) => a.start - b.start);
+}
+
+describe("align.ts — transcript alignment", () => {
+  it("normalises case, punctuation and compatibility forms", () => {
+    assert.equal(normalizeToken("Ramaris,"), "ramaris");
+    assert.equal(normalizeToken("“Hello”"), "hello");
+    assert.equal(normalizeToken("ＣapCut"), "capcut");
+    assert.equal(normalizeToken("—"), "");
+    assert.deepEqual(tokenizeScript("one two\n\n—\nthree"), [["one", "two"], ["three"]]);
+  });
+
+  it("keeps whisper timing, takes the script wording, and interpolates unheard words", () => {
+    const recognized = HEARD_WORDS.map((w) => ({
+      word: w.word,
+      startUs: Math.round(w.start * 1e6),
+      endUs: Math.round(w.end * 1e6),
+    }));
+    const { words, lines, report } = alignScript(tokenizeScript(SCRIPT), recognized);
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0].map((w) => w.word).join(" "), "Welcome to the channel, today we talk about Ramaris.");
+    // Substitutions inherit the mis-heard word's timing.
+    const channel = words.find((w) => w.word === "channel,");
+    assert.equal(channel.matched, false);
+    assert.equal(channel.startUs, 600_000);
+    assert.equal(channel.endUs, 1_000_000);
+    const ramaris = words.find((w) => w.word === "Ramaris.");
+    assert.equal(ramaris.startUs, 2_100_000);
+    // The second line was never spoken in the recognised words: extrapolated
+    // after the last timed word at the median recognised word length (300 ms).
+    const second = lines[1];
+    assert.equal(second[0].startUs, 2_700_000);
+    assert.equal(second[second.length - 1].endUs, 2_700_000 + second.length * 300_000);
+    assert.ok(second.every((w) => w.matched === false));
+    for (let k = 1; k < words.length; k++) assert.ok(words[k].startUs >= words[k - 1].endUs, "monotonic timing");
+
+    assert.equal(report.script_words, 14);
+    assert.equal(report.recognized_words, 9);
+    assert.equal(report.matched, 7);
+    assert.equal(report.substituted, 2);
+    assert.equal(report.inserted, 5);
+    assert.equal(report.dropped, 0);
+    assert.equal(report.match_ratio, 0.5);
+  });
+
+  it("drops recognised words the script does not contain", () => {
+    const recognized = [
+      { word: "um", startUs: 0, endUs: 200_000 },
+      { word: "hello", startUs: 200_000, endUs: 600_000 },
+      { word: "uh", startUs: 600_000, endUs: 700_000 },
+      { word: "world", startUs: 700_000, endUs: 1_100_000 },
+    ];
+    const { words, report } = alignScript([["Hello", "world!"]], recognized);
+    assert.deepEqual(
+      words.map((w) => [w.word, w.startUs, w.endUs, w.matched]),
+      [
+        ["Hello", 200_000, 600_000, true],
+        ["world!", 700_000, 1_100_000, true],
+      ],
+    );
+    assert.equal(report.dropped, 2);
+    assert.equal(report.match_ratio, 1);
+  });
+});
+
+describe("capcut caption --script (fake whisper)", () => {
+  it("one cue per script line with the script's wording and whisper's timing; reports the alignment", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const s = scratch();
+    t.after(s.cleanup);
+    const audio = join(s.dir, "voice.wav");
+    writeFileSync(audio, "stub");
+    const script = join(s.dir, "script.txt");
+    writeFileSync(script, SCRIPT);
+    // Non-karaoke captions request SRT from whisper: cue-level timing only.
+    const heardSrt = join(s.dir, "heard.srt");
+    writeFileSync(
+      heardSrt,
+      "1\n00:00:00,000 --> 00:00:01,000\nwelcome to the chanel\n\n2\n00:00:01,200 --> 00:00:02,700\ntoday we talk about ramarys\n",
+    );
+
+    const r = spawnCli(
+      [
+        "caption",
+        fix.path,
+        "--audio",
+        audio,
+        "--whisper-cmd",
+        FAKE_WHISPER,
+        "--script",
+        script,
+        "--track-name",
+        "scripted",
+        // The first script line is 52 characters; the default --max-chars (42)
+        // would split it — lines are the cue boundary only up to that width.
+        "--max-chars",
+        "80",
+      ],
+      { env: { FAKE_WHISPER_SOURCE: heardSrt } },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.cues, 2);
+    assert.equal(r.json.track_name, "scripted");
+    assert.ok(r.json.script, "the alignment report rides along");
+    assert.equal(r.json.script.script_words, 14);
+    assert.equal(r.json.script.matched, 7);
+    assert.equal(r.json.script.inserted, 5);
+
+    const cues = textCues(fix.path).filter((c) => c.track === "scripted");
+    assert.equal(cues.length, 2);
+    assert.equal(cues[0].text, "Welcome to the channel, today we talk about Ramaris.");
+    assert.equal(cues[0].start, 0, "the cue starts where whisper heard the first word");
+    assert.equal(cues[0].end, 2_700_000, "and ends where it heard the last one");
+    assert.equal(cues[1].text, "And the sidecar it writes.");
+    assert.equal(cues[1].start, 2_700_000, "unheard words follow the last timed word");
+    assert.ok(!/Check that --script belongs/.test(r.stderr), "50% matched is not below the warning threshold");
+  });
+
+  it("--karaoke keeps per-word timing from the JSON transcript with the script's words", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const s = scratch();
+    t.after(s.cleanup);
+    const audio = join(s.dir, "voice.wav");
+    writeFileSync(audio, "stub");
+    const script = join(s.dir, "script.txt");
+    writeFileSync(script, "Welcome to the channel, today we talk about Ramaris.\n");
+    const heardJson = join(s.dir, "heard.json");
+    writeFileSync(heardJson, whisperJson());
+
+    const r = spawnCli(
+      [
+        "caption",
+        fix.path,
+        "--audio",
+        audio,
+        "--whisper-cmd",
+        FAKE_WHISPER,
+        "--script",
+        script,
+        "--karaoke",
+        "--track-name",
+        "kara",
+      ],
+      { env: { FAKE_WHISPER_SOURCE: heardJson } },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.karaoke, true);
+    assert.equal(r.json.script.script_words, 9);
+    assert.equal(r.json.script.matched, 7);
+    assert.equal(r.json.script.substituted, 2);
+    const cues = textCues(fix.path).filter((c) => c.track === "kara");
+    // Karaoke writes one segment per word, each carrying the whole cue text.
+    const channelSeg = cues.find((c) => c.start === 600_000);
+    assert.ok(channelSeg, "the corrected word keeps the mis-heard word's start");
+    assert.equal(channelSeg.end, 1_000_000);
+    assert.match(channelSeg.text, /channel,/);
+    assert.ok(!/chanel/.test(channelSeg.text), "whisper's spelling is gone");
+  });
+
+  it("warns when the script does not match the audio, and fails on a missing script file", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const s = scratch();
+    t.after(s.cleanup);
+    const audio = join(s.dir, "voice.wav");
+    writeFileSync(audio, "stub");
+    const heardSrt = join(s.dir, "heard.srt");
+    writeFileSync(heardSrt, "1\n00:00:00,000 --> 00:00:02,000\nwelcome to the chanel today we talk\n");
+    const wrongScript = join(s.dir, "wrong.txt");
+    writeFileSync(wrongScript, "Quarterly revenue grew twelve percent on strong demand.\n");
+
+    const r = spawnCli(
+      ["caption", fix.path, "--audio", audio, "--whisper-cmd", FAKE_WHISPER, "--script", wrongScript],
+      {
+        env: { FAKE_WHISPER_SOURCE: heardSrt },
+      },
+    );
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stderr, /Check that --script belongs to this audio/);
+    assert.ok(r.json.script.match_ratio < 0.5);
+
+    const missing = spawnCli(
+      ["caption", fix.path, "--audio", audio, "--whisper-cmd", FAKE_WHISPER, "--script", join(s.dir, "nope.txt")],
+      {
+        env: { FAKE_WHISPER_SOURCE: heardSrt },
+      },
+    );
+    assert.notEqual(missing.status, 0);
+    assert.match(missing.stderr, /--script file not found/);
+  });
+
+  it("without --script the result has no script block (byte-identical JSON shape)", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const s = scratch();
+    t.after(s.cleanup);
+    const audio = join(s.dir, "voice.wav");
+    writeFileSync(audio, "stub");
+    const heardSrt = join(s.dir, "heard.srt");
+    writeFileSync(heardSrt, "1\n00:00:00,000 --> 00:00:02,000\nwelcome to the chanel\n");
+    const r = spawnCli(["caption", fix.path, "--audio", audio, "--whisper-cmd", FAKE_WHISPER], {
+      env: { FAKE_WHISPER_SOURCE: heardSrt },
+    });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.script, undefined);
+    assert.equal(r.json.cues, 1);
+  });
+
+  it("describe lists --script on caption", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "caption");
+    assert.ok(spec.options.some((o) => o.flags.includes("--script")));
+  });
+});

--- a/test/detect-retakes.test.mjs
+++ b/test/detect-retakes.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// detect-retakes: repeated takes in caption cues → cut the earlier one, keep
+// the later. Three guards (window, min words, similarity) are what separate it
+// from the "collapsed 29 minutes into 1:47" failure it was designed against.
+
+function srt(cues) {
+  const stamp = (s) => {
+    const ms = Math.round(s * 1000);
+    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
+    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
+    const sec = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
+    const milli = String(ms % 1000).padStart(3, "0");
+    return `${h}:${m}:${sec},${milli}`;
+  };
+  return cues.map((c, i) => `${i + 1}\n${stamp(c.start)} --> ${stamp(c.end)}\n${c.text}\n`).join("\n");
+}
+
+const TAKES = [
+  { start: 0, end: 3, text: "Welcome back to the channel, today we look at CapCut drafts" },
+  { start: 3.5, end: 6.5, text: "welcome back to the channel today we look at capcut drafts." },
+  { start: 7, end: 9, text: "First, the timeline file." },
+  { start: 9.5, end: 12, text: "Okay so" },
+  { start: 12.5, end: 14, text: "Okay so" },
+  { start: 15, end: 18, text: "The sidecar registers every media file you import." },
+];
+
+function scratchSrt(cues) {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-retakes-"));
+  const path = join(dir, "cues.srt");
+  writeFileSync(path, srt(cues));
+  return { dir, path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("detect-retakes", () => {
+  it("--srt: finds the repeated sentence, cuts the earlier take, keeps the later; short cues never count", (t) => {
+    const s = scratchSrt(TAKES);
+    t.after(s.cleanup);
+    const r = spawnCli(["detect-retakes", "--srt", s.path]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.cues, 6);
+    assert.equal(r.json.retakes.length, 1, JSON.stringify(r.json.retakes));
+    const [pair] = r.json.retakes;
+    assert.equal(pair.earlier.start, 0);
+    assert.equal(pair.earlier.end, 3);
+    assert.equal(pair.later.start, 3.5);
+    assert.equal(pair.similarity, 1, "punctuation and case never count against a repeat");
+    assert.equal(pair.words, 11);
+    // "Okay so" repeats but is below --min-words.
+    assert.ok(!r.json.retakes.some((p) => /okay so/i.test(p.earlier.text)));
+    assert.deepEqual(
+      r.json.cuts.map((c) => [c.start, c.end, c.start_us, c.end_us]),
+      [[0, 3, 0, 3_000_000]],
+    );
+    // Keeps are the complement over the last cue's end (18 s).
+    assert.deepEqual(
+      r.json.keeps.map((k) => [k.start, k.end]),
+      [[3, 18]],
+    );
+    assert.equal(r.json.duration_us, 18_000_000);
+    assert.equal(r.json.window, 60);
+    assert.equal(r.json.similarity, 0.8);
+    assert.equal(r.json.min_words, 4);
+  });
+
+  it("the window guard: a repeat too far away is not a retake", (t) => {
+    const far = [TAKES[0], { start: 200, end: 203, text: TAKES[1].text }];
+    const s = scratchSrt(far);
+    t.after(s.cleanup);
+    const r = spawnCli(["detect-retakes", "--srt", s.path]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.retakes.length, 0);
+    const wide = spawnCli(["detect-retakes", "--srt", s.path, "--window", "300"]);
+    assert.equal(wide.json.retakes.length, 1);
+  });
+
+  it("the similarity guard: a rephrased sentence is not a repeat unless the floor is lowered", (t) => {
+    const cues = [
+      { start: 0, end: 3, text: "the sidecar registers every media file you import" },
+      { start: 4, end: 7, text: "the sidecar lists every media file that you import into the draft" },
+    ];
+    const s = scratchSrt(cues);
+    t.after(s.cleanup);
+    const strict = spawnCli(["detect-retakes", "--srt", s.path]);
+    assert.equal(strict.json.retakes.length, 0);
+    const loose = spawnCli(["detect-retakes", "--srt", s.path, "--similarity", "0.6"]);
+    assert.equal(loose.json.retakes.length, 1);
+    assert.ok(loose.json.retakes[0].similarity >= 0.6 && loose.json.retakes[0].similarity < 0.8);
+  });
+
+  it("three attempts keep the last one: two pairs, two adjacent cuts merged when they touch", (t) => {
+    const cues = [
+      { start: 0, end: 2, text: "we ship nine items in every release" },
+      { start: 2, end: 4, text: "we ship nine items in every release" },
+      { start: 4.5, end: 6.5, text: "we ship nine items in every release" },
+    ];
+    const s = scratchSrt(cues);
+    t.after(s.cleanup);
+    const r = spawnCli(["detect-retakes", "--srt", s.path]);
+    assert.equal(r.json.retakes.length, 2);
+    assert.deepEqual(
+      r.json.cuts.map((c) => [c.start, c.end]),
+      [[0, 4]],
+      "touching earlier takes merge into one cut",
+    );
+    assert.deepEqual(
+      r.json.keeps.map((k) => [k.start, k.end]),
+      [[4, 6.5]],
+    );
+  });
+
+  it("project form: reads the draft's text tracks, bounds keeps by the draft duration, honours --track-name", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const s = scratchSrt(TAKES);
+    t.after(s.cleanup);
+    const imported = spawnCli(["import-srt", fix.path, s.path, "--track-name", "takes"]);
+    assert.equal(imported.status, 0, `stderr: ${imported.stderr}`);
+
+    const r = spawnCli(["detect-retakes", fix.path, "--track-name", "takes"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.source, "takes");
+    assert.equal(r.json.retakes.length, 1);
+    assert.equal(r.json.retakes[0].earlier.start_us, 0);
+    assert.equal(r.json.retakes[0].later.start_us, 3_500_000);
+
+    const wrong = spawnCli(["detect-retakes", fix.path, "--track-name", "nope"]);
+    assert.notEqual(wrong.status, 0);
+    assert.match(wrong.stderr, /No text track named/);
+
+    // The fixture's own caption text is never mistaken for a retake of the imported cues.
+    const all = spawnCli(["detect-retakes", fix.path]);
+    assert.equal(all.status, 0, `stderr: ${all.stderr}`);
+    assert.equal(all.json.retakes.length, 1);
+  });
+
+  it("-H prints the pairs with cut/keep text; --json wins over -H", (t) => {
+    const s = scratchSrt(TAKES);
+    t.after(s.cleanup);
+    const human = spawnCli(["detect-retakes", "--srt", s.path, "-H"]);
+    assert.equal(human.status, 0, `stderr: ${human.stderr}`);
+    assert.match(human.stdout, /Retakes:\s+1/);
+    assert.match(human.stdout, /cut:\s+Welcome back to the channel/);
+    assert.match(human.stdout, /keep:\s+welcome back to the channel/);
+    assert.match(human.stdout, /Next: pipe the keep segments/);
+    const forced = spawnCli(["detect-retakes", "--srt", s.path, "-H", "--json"]);
+    assert.ok(forced.json && Array.isArray(forced.json.retakes));
+  });
+
+  it("validates its guards and refuses a project together with --srt", (t) => {
+    const s = scratchSrt(TAKES);
+    t.after(s.cleanup);
+    for (const [flag, value, message] of [
+      ["--window", "0", /--window must be > 0/],
+      ["--similarity", "1.5", /--similarity must be in \(0, 1\]/],
+      ["--min-words", "0", /--min-words must be a positive integer/],
+    ]) {
+      const r = spawnCli(["detect-retakes", "--srt", s.path, flag, value]);
+      assert.notEqual(r.status, 0, `${flag} ${value} should fail`);
+      assert.match(r.stderr, message);
+    }
+    const both = spawnCli(["detect-retakes", s.path, "--srt", s.path]);
+    assert.notEqual(both.status, 0);
+    assert.match(both.stderr, /drop the <project> argument/);
+    const missing = spawnCli(["detect-retakes", "--srt", join(s.dir, "nope.srt")]);
+    assert.notEqual(missing.status, 0);
+    assert.match(missing.stderr, /--srt file not found/);
+  });
+
+  it("describe lists detect-retakes as a non-mutating command with its guards", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "detect-retakes");
+    assert.ok(spec, "describe must list detect-retakes");
+    assert.equal(spec.mutates, false);
+    for (const flag of ["--window", "--similarity", "--min-words", "--srt", "--track-name"]) {
+      assert.ok(
+        spec.options.some((o) => o.flags.includes(flag)),
+        `${flag} declared`,
+      );
+    }
+  });
+});

--- a/test/export-timeline-captions.test.mjs
+++ b/test/export-timeline-captions.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { extractText } from "../dist/draft.js";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// `export-timeline --captions markers`: caption cues travel as OTIO timeline
+// markers on the Stack (OTIO has no title schema — OpenTimelineIO#62, open
+// since 2017), and `import-timeline` rebuilds the text track from them.
+
+function textCues(path) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  const cues = [];
+  for (const track of draft.tracks) {
+    if (track.type !== "text") continue;
+    for (const seg of track.segments) {
+      const mat = draft.materials.texts.find((m) => m.id === seg.material_id);
+      const text = mat && typeof mat.content === "string" ? extractText(mat.content) : "";
+      if (text)
+        cues.push({
+          track: track.name,
+          text,
+          start: seg.target_timerange.start,
+          duration: seg.target_timerange.duration,
+        });
+    }
+  }
+  return cues.sort((a, b) => a.start - b.start);
+}
+
+describe("export-timeline --captions markers", () => {
+  it("default output is unchanged: no markers, text tracks skipped with the pointer", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const r = spawnCli(["export-timeline", fix.path]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.tracks.markers, []);
+    assert.match(r.stderr, /--captions markers/);
+  });
+
+  it("writes one Marker.1 per caption cue on the Stack, with the cue text as name and capcut metadata", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const cues = textCues(fix.path);
+    assert.ok(cues.length > 0, "fixture must carry captions");
+    const draft = JSON.parse(readFileSync(fix.path, "utf-8"));
+    const rate = draft.fps || 30;
+
+    const r = spawnCli(["export-timeline", fix.path, "--captions", "markers"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const markers = r.json.tracks.markers;
+    assert.equal(markers.length, cues.length);
+    for (const [i, marker] of markers.entries()) {
+      assert.equal(marker.OTIO_SCHEMA, "Marker.1");
+      assert.equal(marker.color, "YELLOW");
+      assert.equal(marker.name, cues[i].text);
+      assert.equal(marker.metadata.capcut.kind, "caption");
+      assert.equal(marker.metadata.capcut.text, cues[i].text);
+      assert.equal(marker.metadata.capcut.track, cues[i].track);
+      assert.equal(marker.metadata.Resolve_OTIO.Note, cues[i].text);
+      assert.equal(marker.marked_range.OTIO_SCHEMA, "TimeRange.1");
+      assert.equal(marker.marked_range.start_time.rate, rate);
+      assert.equal(marker.marked_range.start_time.value, Math.round((cues[i].start / 1e6) * rate));
+      assert.ok(marker.marked_range.duration.value >= 1);
+    }
+    // No text track is reported as skipped when it travelled as markers.
+    assert.ok(!r.stderr.includes("OTIO has no standard title schema"), r.stderr);
+  });
+
+  it("--out reports the marker count and refuses an unknown mode", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const dir = mkdtempSync(join(tmpdir(), "capcut-otio-captions-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const outFile = join(dir, "cut.otio");
+    const r = spawnCli(["export-timeline", fix.path, "--out", outFile, "--captions", "markers"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.captions, textCues(fix.path).length);
+    const plain = spawnCli(["export-timeline", fix.path, "--out", outFile]);
+    assert.equal(plain.json.captions, undefined, "the default JSON keeps its shape");
+    const bad = spawnCli(["export-timeline", fix.path, "--captions", "burn"]);
+    assert.notEqual(bad.status, 0);
+    assert.match(bad.stderr, /--captions must be skip\|markers/);
+  });
+
+  it("import-timeline rebuilds the text track from the caption markers, reports foreign markers", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const dir = mkdtempSync(join(tmpdir(), "capcut-otio-roundtrip-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const otioPath = join(dir, "cut.otio");
+    const exp = spawnCli(["export-timeline", fix.path, "--out", otioPath, "--captions", "markers"]);
+    assert.equal(exp.status, 0, `stderr: ${exp.stderr}`);
+
+    // Add an editor's own marker (no capcut metadata): it must be reported, not imported.
+    const doc = JSON.parse(readFileSync(otioPath, "utf-8"));
+    doc.tracks.markers.push({
+      OTIO_SCHEMA: "Marker.1",
+      color: "RED",
+      marked_range: doc.tracks.markers[0].marked_range,
+      metadata: {},
+      name: "editor note",
+    });
+    writeFileSync(otioPath, JSON.stringify(doc));
+
+    const outDir = join(dir, "rebuilt");
+    const imp = spawnCli(["import-timeline", otioPath, "--out", outDir]);
+    assert.equal(imp.status, 0, `stderr: ${imp.stderr}`);
+    const expected = textCues(fix.path);
+    assert.equal(imp.json.captions, expected.length);
+    assert.ok(
+      imp.json.skipped.some(
+        (s) => s.type === "markers" && /1 timeline marker\(s\) without capcut caption metadata/.test(s.reason),
+      ),
+      JSON.stringify(imp.json.skipped),
+    );
+
+    const rebuilt = textCues(join(outDir, "draft_content.json"));
+    assert.equal(rebuilt.length, expected.length);
+    const draft = JSON.parse(readFileSync(fix.path, "utf-8"));
+    const frameUs = 1e6 / (draft.fps || 30);
+    for (const [i, cue] of rebuilt.entries()) {
+      assert.equal(cue.text, expected[i].text);
+      assert.equal(cue.track, expected[i].track, "cues land back on the recorded track name");
+      assert.ok(
+        Math.abs(cue.start - expected[i].start) <= frameUs,
+        `start within a frame: ${cue.start} vs ${expected[i].start}`,
+      );
+      assert.ok(Math.abs(cue.duration - expected[i].duration) <= frameUs, "duration within a frame");
+    }
+  });
+
+  it("a document without caption markers imports exactly as before (no captions key)", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const dir = mkdtempSync(join(tmpdir(), "capcut-otio-plain-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const otioPath = join(dir, "cut.otio");
+    assert.equal(spawnCli(["export-timeline", fix.path, "--out", otioPath]).status, 0);
+    const imp = spawnCli(["import-timeline", otioPath, "--out", join(dir, "rebuilt")]);
+    assert.equal(imp.status, 0, `stderr: ${imp.stderr}`);
+    assert.equal(imp.json.captions, undefined);
+    assert.equal(textCues(join(dir, "rebuilt", "draft_content.json")).length, 0);
+  });
+
+  it("describe advertises --captions on export-timeline", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "export-timeline");
+    const opt = spec.options.find((o) => o.flags.includes("--captions"));
+    assert.deepEqual(opt.values, ["skip", "markers"]);
+    assert.equal(opt.default, "skip");
+  });
+});

--- a/test/helpers/fake-whisper.mjs
+++ b/test/helpers/fake-whisper.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// A stand-in for the whisper CLI (openai dialect): ignores the audio, writes
+// the transcript named by FAKE_WHISPER_SOURCE into --output_dir under the
+// requested --output_format (json → transcript.json, srt → transcript.srt).
+// Lets caption's pipeline run end-to-end in tests without a model or audio.
+import { copyFileSync } from "node:fs";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+const value = (flag) => {
+  const i = args.indexOf(flag);
+  return i === -1 ? undefined : args[i + 1];
+};
+const outDir = value("--output_dir");
+const format = value("--output_format") ?? "srt";
+const source = process.env.FAKE_WHISPER_SOURCE;
+// `node --test` runs every file under test/, this helper included: with no
+// whisper-style arguments there is nothing to fake, so exit clean.
+if (args.length === 0 && !source) process.exit(0);
+if (!outDir || !source) {
+  process.stderr.write("fake-whisper: need --output_dir and FAKE_WHISPER_SOURCE\n");
+  process.exit(2);
+}
+copyFileSync(source, join(outDir, `transcript.${format}`));

--- a/test/init-canvas.test.mjs
+++ b/test/init-canvas.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+// Canvas at creation: the bundled template is 1920x1080 16:9; --ratio picks a
+// CapCut-native preset size, --width/--height set an exact canvas.
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "capcut-init-canvas-"));
+  return { dir, drafts: join(dir, "drafts"), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function canvasOf(draftPath) {
+  const file = join(draftPath, "draft_content.json");
+  return JSON.parse(readFileSync(file, "utf-8")).canvas_config;
+}
+
+describe("init / quickstart canvas flags", () => {
+  it("keeps the template canvas when no flag is given (canvas: null in the output)", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const r = spawnCli(["init", "plain", "--drafts", s.drafts]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.canvas, null);
+    assert.deepEqual(canvasOf(r.json.draft_path), { width: 1920, height: 1080, ratio: "16:9" });
+  });
+
+  it("--ratio 9:16 creates a 1080x1920 portrait canvas", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const r = spawnCli(["init", "portrait", "--drafts", s.drafts, "--ratio", "9:16"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.canvas, { width: 1080, height: 1920, ratio: "9:16" });
+    assert.deepEqual(canvasOf(r.json.draft_path), { width: 1080, height: 1920, ratio: "9:16" });
+    assert.match(r.stderr, /Canvas: 1080x1920 \(9:16\)/);
+  });
+
+  it("--width/--height set an exact canvas and label it from the matching preset", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const square = spawnCli(["init", "square", "--drafts", s.drafts, "--width", "1200", "--height", "1200"]);
+    assert.equal(square.status, 0, `stderr: ${square.stderr}`);
+    assert.deepEqual(square.json.canvas, { width: 1200, height: 1200, ratio: "1:1" });
+
+    const custom = spawnCli(["init", "custom", "--drafts", s.drafts, "--width", "1000", "--height", "700"]);
+    assert.equal(custom.status, 0, `stderr: ${custom.stderr}`);
+    assert.deepEqual(custom.json.canvas, { width: 1000, height: 700, ratio: "original" });
+  });
+
+  it("explicit size wins over the preset's size but keeps its label", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const r = spawnCli(["init", "hd", "--drafts", s.drafts, "--ratio", "9:16", "--width", "720", "--height", "1280"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.canvas, { width: 720, height: 1280, ratio: "9:16" });
+  });
+
+  it("refuses a half-specified canvas and an unknown preset", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const half = spawnCli(["init", "half", "--drafts", s.drafts, "--width", "1080"]);
+    assert.notEqual(half.status, 0);
+    assert.match(half.stderr, /--width and --height must be given together/);
+    const bad = spawnCli(["init", "bad", "--drafts", s.drafts, "--ratio", "5:4"]);
+    assert.notEqual(bad.status, 0);
+    assert.match(bad.stderr, /Unknown --ratio 5:4/);
+    const fraction = spawnCli(["init", "frac", "--drafts", s.drafts, "--width", "100.5", "--height", "200"]);
+    assert.notEqual(fraction.status, 0);
+    assert.match(fraction.stderr, /positive integer pixel count/);
+  });
+
+  it("quickstart passes the canvas through and reports it in the create step", (t) => {
+    const s = scratch();
+    t.after(s.cleanup);
+    const video = join(s.dir, "clip.mp4");
+    writeFileSync(video, "not-a-real-video");
+    const r = spawnCli(["quickstart", "short", "--video", video, "--drafts", s.drafts, "--ratio", "9:16"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.canvas, { width: 1080, height: 1920, ratio: "9:16" });
+    assert.deepEqual(canvasOf(r.json.draft_path), { width: 1080, height: 1920, ratio: "9:16" });
+    const create = r.json.steps.find((step) => step.step === "create");
+    assert.match(create.detail, /Canvas 1080x1920 \(9:16\)/);
+  });
+
+  it("describe advertises --ratio with the preset values on init and quickstart", () => {
+    const r = spawnCli(["describe"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    for (const name of ["init", "quickstart"]) {
+      const spec = r.json.commands.find((c) => c.name === name);
+      const ratio = spec.options.find((o) => o.flags.includes("--ratio"));
+      assert.ok(ratio, `${name} must declare --ratio`);
+      assert.deepEqual(ratio.values, ["16:9", "9:16", "1:1", "4:3", "3:4"]);
+      assert.ok(spec.options.some((o) => o.flags.includes("--width")));
+      assert.ok(spec.options.some((o) => o.flags.includes("--height")));
+    }
+  });
+});

--- a/test/keyframe-aliases.test.mjs
+++ b/test/keyframe-aliases.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { after, describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// IR-style keyframe property names (the translation table every downstream
+// integrator re-implements: vertir's PROP_MAP, qcut's spec.py) are accepted
+// and stored under the canonical on-disk property_type.
+
+const SEG = "aaaaaa01-0000-0000-0000-000000000001";
+
+function keyframeLists(path, segId = SEG) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  for (const track of draft.tracks) {
+    const seg = track.segments.find((s) => s.id === segId);
+    if (seg) return seg.common_keyframes ?? [];
+  }
+  return [];
+}
+
+describe("keyframe property aliases", () => {
+  const fix = tmpDraft();
+  after(() => fix.cleanup());
+
+  it("scale → UNIFORM_SCALE, reported under the canonical name", () => {
+    const r = spawnCli(["keyframe", fix.path, SEG, "scale", "0s", "1.5"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const list = keyframeLists(fix.path).find((l) => l.property_type === "UNIFORM_SCALE");
+    assert.ok(list, "alias must land on the uniform_scale list");
+    assert.deepEqual(list.keyframe_list[0].values, [1.5]);
+    assert.ok(r.json.lists.some((l) => l.property === "uniform_scale"));
+    assert.ok(!r.json.lists.some((l) => l.property === "scale"), "output uses canonical names only");
+  });
+
+  it("x / y → KFTypePositionX / KFTypePositionY with the position range check", () => {
+    const x = spawnCli(["keyframe", fix.path, SEG, "x", "0s", "0.25"]);
+    assert.equal(x.status, 0, `stderr: ${x.stderr}`);
+    const y = spawnCli(["keyframe", fix.path, SEG, "y", "0s", "-0.5"]);
+    assert.equal(y.status, 0, `stderr: ${y.stderr}`);
+    const lists = keyframeLists(fix.path);
+    assert.deepEqual(lists.find((l) => l.property_type === "KFTypePositionX").keyframe_list[0].values, [0.25]);
+    assert.deepEqual(lists.find((l) => l.property_type === "KFTypePositionY").keyframe_list[0].values, [-0.5]);
+
+    const outOfRange = spawnCli(["keyframe", fix.path, SEG, "x", "1s", "42"]);
+    assert.notEqual(outOfRange.status, 0);
+    assert.match(outOfRange.stderr, /position_x must be a finite number in \[-10, 10\]/);
+  });
+
+  it("opacity → KFTypeAlpha, percentages included", () => {
+    const r = spawnCli(["keyframe", fix.path, SEG, "opacity", "0s", "50%"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const list = keyframeLists(fix.path).find((l) => l.property_type === "KFTypeAlpha");
+    assert.deepEqual(list.keyframe_list[0].values, [0.5]);
+  });
+
+  it("aliases work per line in --batch and merge into the canonical list", () => {
+    const input = [
+      '{"property":"scale","time":"1s","value":"2"}',
+      '{"property":"uniform_scale","time":"2s","value":"1"}',
+    ].join("\n");
+    const r = spawnCli(["keyframe", fix.path, SEG, "--batch"], { input });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const list = keyframeLists(fix.path).find((l) => l.property_type === "UNIFORM_SCALE");
+    assert.equal(list.keyframe_list.length, 3, "alias and canonical name share one list");
+    assert.equal(keyframeLists(fix.path).filter((l) => l.property_type === "UNIFORM_SCALE").length, 1);
+  });
+
+  it("an unknown name still fails, and the error lists the aliases", () => {
+    const r = spawnCli(["keyframe", fix.path, SEG, "zoom", "0s", "1"]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /Unsupported keyframe property: zoom/);
+    assert.match(r.stderr, /aliases: scale=uniform_scale, x=position_x, y=position_y, opacity=alpha/);
+  });
+});

--- a/test/keyframe-hold.test.mjs
+++ b/test/keyframe-hold.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// `--easing hold`: CapCut always interpolates, so a step is emulated with a
+// helper keyframe one frame before the NEXT keyframe on the same property.
+
+const SEG = "aaaaaa01-0000-0000-0000-000000000001";
+
+function list(path, propertyType, segId = SEG) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  for (const track of draft.tracks) {
+    const seg = track.segments.find((s) => s.id === segId);
+    if (seg) return (seg.common_keyframes ?? []).find((l) => l.property_type === propertyType)?.keyframe_list ?? [];
+  }
+  return [];
+}
+
+function frameUs(path) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  return Math.round(1_000_000 / (draft.fps || 30));
+}
+
+describe("keyframe --easing hold", () => {
+  it("holds the value with a helper keyframe one frame before the next keyframe", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const first = spawnCli(["keyframe", fix.path, SEG, "alpha", "0s", "1", "--easing", "hold"]);
+    assert.equal(first.status, 0, `stderr: ${first.stderr}`);
+    assert.equal(first.json.hold_keyframes, undefined, "nothing to hold until yet");
+    assert.match(first.stderr, /no later keyframe to hold until/);
+
+    const second = spawnCli(["keyframe", fix.path, SEG, "alpha", "2s", "0"]);
+    assert.equal(second.status, 0, `stderr: ${second.stderr}`);
+    // The hold was requested on the FIRST keyframe; adding the second one
+    // linearly does not retroactively step it — re-issue the hold now.
+    const held = spawnCli(["keyframe", fix.path, SEG, "alpha", "0s", "1", "--easing", "hold"]);
+    assert.equal(held.status, 0, `stderr: ${held.stderr}`);
+    assert.equal(held.json.hold_keyframes, 1);
+
+    const entries = list(fix.path, "KFTypeAlpha");
+    assert.deepEqual(
+      entries.map((k) => k.time_offset),
+      [0, 0, 2_000_000 - frameUs(fix.path), 2_000_000],
+    );
+    const helper = entries[2];
+    assert.deepEqual(helper.values, [1], "the helper carries the held value");
+    assert.equal(helper.curveType, "Line");
+    assert.deepEqual(helper.left_control, { x: 0, y: 0 });
+  });
+
+  it("--batch: a hold named before its pair keyframe in the same call still steps", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const input = [
+      '{"property":"scale","time":"0s","value":"1","easing":"hold"}',
+      '{"property":"scale","time":"1s","value":"2"}',
+      '{"property":"scale","time":"3s","value":"1","easing":"hold"}',
+      '{"property":"scale","time":"4s","value":"3"}',
+    ].join("\n");
+    const r = spawnCli(["keyframe", fix.path, SEG, "--batch"], { input });
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.added, 4);
+    assert.equal(r.json.hold_keyframes, 2);
+    const f = frameUs(fix.path);
+    const times = list(fix.path, "UNIFORM_SCALE").map((k) => k.time_offset);
+    assert.deepEqual(times, [0, 1_000_000 - f, 1_000_000, 3_000_000, 4_000_000 - f, 4_000_000]);
+    const values = list(fix.path, "UNIFORM_SCALE").map((k) => k.values[0]);
+    assert.deepEqual(values, [1, 1, 2, 1, 1, 3]);
+    assert.ok(r.json.lists.some((l) => l.property === "uniform_scale" && l.count === 6));
+  });
+
+  it("does not invent a keyframe when the next one is within a frame, and never duplicates a helper", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const f = frameUs(fix.path);
+    const input = [
+      '{"property":"alpha","time":"0s","value":"1","easing":"hold"}',
+      `{"property":"alpha","time":${f},"value":"0"}`,
+    ].join("\n");
+    const tight = spawnCli(["keyframe", fix.path, SEG, "--batch"], { input });
+    assert.equal(tight.status, 0, `stderr: ${tight.stderr}`);
+    assert.equal(tight.json.hold_keyframes, undefined);
+    assert.match(tight.stderr, /within one frame, nothing to hold/);
+
+    const again = spawnCli(["keyframe", fix.path, SEG, "alpha", "5s", "0.5", "--easing", "hold"]);
+    assert.equal(again.status, 0);
+    const more = spawnCli(["keyframe", fix.path, SEG, "alpha", "8s", "0", "--easing", "linear"]);
+    assert.equal(more.status, 0);
+    const first = spawnCli(["keyframe", fix.path, SEG, "alpha", "5s", "0.5", "--easing", "hold"]);
+    assert.equal(first.json.hold_keyframes, 1);
+    const second = spawnCli(["keyframe", fix.path, SEG, "alpha", "5s", "0.5", "--easing", "hold"]);
+    assert.equal(second.json.hold_keyframes, undefined, "the helper already exists — not written twice");
+    assert.equal(list(fix.path, "KFTypeAlpha").filter((k) => k.time_offset === 8_000_000 - f).length, 1);
+  });
+
+  it("describe lists hold among the easings", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "keyframe");
+    const easing = spec.options.find((o) => o.flags.includes("--easing"));
+    assert.ok(easing.values.includes("hold"));
+  });
+});

--- a/test/lint-media-unregistered.test.mjs
+++ b/test/lint-media-unregistered.test.mjs
@@ -58,8 +58,8 @@ describe("lint media-unregistered (pyCapCut#13, observe-only)", () => {
     const issue = r.json.issues.find((i) => i.code === "media-unregistered");
     assert.ok(issue, "the empty sidecar must be surfaced");
     assert.equal(issue.severity, "info");
-    assert.equal(issue.fixable, false, "the registration write is deliberately out of scope");
-    assert.match(issue.suggested_command, /capcut fixture/);
+    assert.equal(issue.fixable, false, "a sidecar write is register's job, not lint --fix's");
+    assert.match(issue.suggested_command, /capcut register .* --materials --apply/);
   });
 
   it("stays silent when draft_materials is not provably empty", () => {

--- a/test/matting.test.mjs
+++ b/test/matting.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
+import { after, describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// Smart matting lives on the VIDEO MATERIAL (materials.videos[].matting), not
+// the segment. Shape: docs/draft-schema/02-materials.md (flag 0, the app's off
+// state) + pyJianYingDraft PRs #183/#184 (flag 3 = smart portrait matting).
+
+function firstSegment(path, trackType) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  const track = draft.tracks.find((t) => t.type === trackType);
+  assert.ok(track, `fixture must contain a ${trackType} track`);
+  return { draft, seg: track.segments[0] };
+}
+
+function materialOf(path, segId) {
+  const draft = JSON.parse(readFileSync(path, "utf-8"));
+  const seg = draft.tracks.flatMap((t) => t.segments).find((s) => s.id === segId);
+  return draft.materials.videos.find((m) => m.id === seg.material_id);
+}
+
+describe("capcut matting", () => {
+  describe("on a video segment", () => {
+    const fix = tmpDraft();
+    after(() => fix.cleanup());
+
+    it("writes flag 3 with the documented off-shape fields on the segment's material", () => {
+      const { seg } = firstSegment(fix.path, "video");
+      const r = spawnCli(["matting", fix.path, seg.id]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.equal(r.json.ok, true);
+      assert.equal(r.json.enabled, true);
+      assert.equal(r.json.flag, 3);
+      assert.equal(r.json.segmentId, seg.id);
+      assert.equal(r.json.materialId, seg.material_id);
+      assert.deepEqual(r.json.shared_segments, []);
+
+      const mat = materialOf(fix.path, seg.id);
+      assert.deepEqual(mat.matting, {
+        flag: 3,
+        has_use_quick_brush: false,
+        has_use_quick_eraser: false,
+        interactiveTime: [],
+        path: "",
+        strokes: [],
+      });
+    });
+
+    it("is idempotent: a second run leaves the same object", () => {
+      const { seg } = firstSegment(fix.path, "video");
+      const before = JSON.stringify(materialOf(fix.path, seg.id).matting);
+      const r = spawnCli(["matting", fix.path, seg.id]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.equal(JSON.stringify(materialOf(fix.path, seg.id).matting), before);
+    });
+
+    it("--off writes flag 0 and keeps the other fields (never deletes the key)", () => {
+      const { seg } = firstSegment(fix.path, "video");
+      const r = spawnCli(["matting", fix.path, seg.id, "--off"]);
+      assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+      assert.equal(r.json.enabled, false);
+      assert.equal(r.json.flag, 0);
+      const mat = materialOf(fix.path, seg.id);
+      assert.equal(mat.matting.flag, 0);
+      assert.deepEqual(mat.matting.strokes, []);
+      assert.equal(mat.matting.path, "");
+    });
+  });
+
+  it("preserves app-authored cache fields when toggling on", () => {
+    const fix = tmpDraft();
+    after(() => fix.cleanup());
+    const { draft, seg } = firstSegment(fix.path, "video");
+    const mat = draft.materials.videos.find((m) => m.id === seg.material_id);
+    mat.matting = {
+      flag: 0,
+      has_use_quick_brush: true,
+      interactiveTime: [1],
+      path: "matting/cache.bin",
+      strokes: [{ x: 1 }],
+    };
+    writeFileSync(fix.path, JSON.stringify(draft));
+
+    const r = spawnCli(["matting", fix.path, seg.id]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const after_ = materialOf(fix.path, seg.id).matting;
+    assert.equal(after_.flag, 3);
+    assert.equal(after_.has_use_quick_brush, true, "app-authored brush flag must survive");
+    assert.equal(after_.path, "matting/cache.bin", "the app's cache path must survive");
+    assert.deepEqual(after_.strokes, [{ x: 1 }]);
+    assert.deepEqual(after_.interactiveTime, [1]);
+    assert.equal(after_.has_use_quick_eraser, false, "missing fields are filled from the documented defaults");
+  });
+
+  it("reports the other segments sharing the material (matting is per material)", () => {
+    const fix = tmpDraft();
+    after(() => fix.cleanup());
+    const { draft, seg } = firstSegment(fix.path, "video");
+    const track = draft.tracks.find((t) => t.type === "video");
+    track.segments.push({
+      ...structuredClone(seg),
+      id: "shared-copy-0000-0000-0000-000000000001",
+      target_timerange: { start: seg.target_timerange.start + seg.target_timerange.duration, duration: 1000 },
+    });
+    writeFileSync(fix.path, JSON.stringify(draft));
+
+    const r = spawnCli(["matting", fix.path, seg.id]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.shared_segments, ["shared-copy-0000-0000-0000-000000000001"]);
+    assert.match(r.stderr, /shared by 1 other segment/);
+  });
+
+  it("refuses a non-video segment", () => {
+    const fix = tmpDraft();
+    after(() => fix.cleanup());
+    const { seg } = firstSegment(fix.path, "text");
+    const r = spawnCli(["matting", fix.path, seg.id]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /only applies to video\/photo segments/);
+  });
+
+  it("fails clearly on an unknown segment id and without an id", () => {
+    const fix = tmpDraft();
+    after(() => fix.cleanup());
+    const unknown = spawnCli(["matting", fix.path, "no-such-segment"]);
+    assert.notEqual(unknown.status, 0);
+    assert.match(unknown.stderr, /Segment not found/);
+    const missing = spawnCli(["matting", fix.path]);
+    assert.notEqual(missing.status, 0);
+    assert.match(missing.stderr, /Usage: capcut matting/);
+  });
+
+  it("is listed by describe as a mutating command with --off", () => {
+    const r = spawnCli(["describe"]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const spec = r.json.commands.find((c) => c.name === "matting");
+    assert.ok(spec, "describe must list matting");
+    assert.equal(spec.mutates, true);
+    assert.ok(spec.options.some((o) => o.flags.includes("--off")));
+  });
+});

--- a/test/register-materials.test.mjs
+++ b/test/register-materials.test.mjs
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+
+// `register --materials` (pyCapCut#13): CapCut 9.1 decides what is imported
+// from draft_meta_info.json's draft_materials, so a tool-built sidecar with
+// empty groups shows every clip as "file inaccessible". Entry shape per
+// pyCapCut PR #14 — matched by file_Path, merged into the type-0 group.
+
+function contentDraft(dir, { photo = false, audio = false } = {}) {
+  const videos = [
+    {
+      id: "V1",
+      type: "video",
+      path: join(dir, "assets", "video", "clip.mp4"),
+      material_name: "clip.mp4",
+      duration: 3_000_000,
+      width: 1920,
+      height: 1080,
+    },
+  ];
+  if (photo) {
+    videos.push({
+      id: "P1",
+      type: "photo",
+      path: join(dir, "assets", "video", "still.png"),
+      material_name: "still.png",
+      duration: 10_800_000_000,
+      width: 800,
+      height: 600,
+    });
+  }
+  const audios = audio
+    ? [
+        {
+          id: "A1",
+          type: "extract_music",
+          path: join(dir, "assets", "audio", "voice.wav"),
+          name: "voice.wav",
+          duration: 2_500_000,
+        },
+      ]
+    : [];
+  const segments = videos.map((v, i) => ({
+    id: `SEG-${i}`,
+    material_id: v.id,
+    target_timerange: { start: i * 3_000_000, duration: 3_000_000 },
+    source_timerange: { start: 0, duration: 3_000_000 },
+  }));
+  return {
+    id: "guid-materials-draft",
+    name: "materials-draft",
+    duration: 3_000_000 * videos.length,
+    fps: 30,
+    canvas_config: { width: 1080, height: 1920, ratio: "9:16" },
+    platform: { app_source: "cc", app_version: "9.1.0", os: "mac" },
+    tracks: [
+      { id: "T1", type: "video", name: "video", attribute: 0, segments },
+      ...(audio
+        ? [
+            {
+              id: "T2",
+              type: "audio",
+              name: "audio",
+              attribute: 0,
+              segments: [
+                {
+                  id: "SEG-A",
+                  material_id: "A1",
+                  target_timerange: { start: 0, duration: 2_500_000 },
+                  source_timerange: { start: 0, duration: 2_500_000 },
+                },
+              ],
+            },
+          ]
+        : []),
+    ],
+    materials: { videos, audios, texts: [], speeds: [], material_animations: [], audio_fades: [], transitions: [] },
+  };
+}
+
+function sidecar(root, dir, draftMaterials) {
+  return {
+    draft_cover: "draft_cover.jpg",
+    draft_fold_path: dir,
+    draft_id: "guid-materials-draft",
+    draft_json_file: join(dir, "draft_content.json"),
+    draft_name: "materials-draft",
+    draft_root_path: root,
+    tm_draft_create: 1_700_000_000_000_000,
+    tm_draft_modified: 1_700_000_000_000_000,
+    tm_draft_removed: 0,
+    tm_duration: 3_000_000,
+    ...(draftMaterials === undefined ? {} : { draft_materials: draftMaterials }),
+  };
+}
+
+function storeFixture({ meta, photo = false, audio = false, withMedia = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "capcut-register-materials-"));
+  const dir = join(root, "Media Draft");
+  mkdirSync(join(dir, "assets", "video"), { recursive: true });
+  mkdirSync(join(dir, "assets", "audio"), { recursive: true });
+  if (withMedia) {
+    writeFileSync(join(dir, "assets", "video", "clip.mp4"), "stub");
+    if (photo) writeFileSync(join(dir, "assets", "video", "still.png"), "stub");
+    if (audio) writeFileSync(join(dir, "assets", "audio", "voice.wav"), "stub");
+  }
+  const content = contentDraft(dir, { photo, audio });
+  writeFileSync(join(dir, "draft_content.json"), JSON.stringify(content, null, 2));
+  if (meta !== null) {
+    writeFileSync(join(dir, "draft_meta_info.json"), JSON.stringify(meta ?? sidecar(root, dir, EMPTY_GROUPS)));
+  }
+  writeFileSync(
+    join(root, "root_meta_info.json"),
+    JSON.stringify({
+      all_draft_store: [
+        {
+          draft_cover: "draft_cover.jpg",
+          draft_fold_path: dir,
+          draft_id: "guid-materials-draft",
+          draft_json_file: join(dir, "draft_content.json"),
+          draft_name: "materials-draft",
+          draft_root_path: root,
+          tm_draft_create: 1_700_000_000_000_000,
+          tm_draft_modified: 1_700_000_000_000_000,
+          tm_draft_removed: 0,
+          tm_duration: 3_000_000 * (photo ? 2 : 1),
+        },
+      ],
+    }),
+  );
+  return { root, dir, content, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+// CapCut's own tool-built sidecar carries every group with an empty value list.
+const EMPTY_GROUPS = [
+  { type: 0, value: [] },
+  { type: 1, value: [] },
+  { type: 2, value: [] },
+];
+
+function metaOnDisk(dir) {
+  return JSON.parse(readFileSync(join(dir, "draft_meta_info.json"), "utf-8"));
+}
+
+describe("register --materials (pyCapCut#13 draft_materials registration)", () => {
+  it("plans the registration without writing anything", () => {
+    const f = storeFixture();
+    after(f.cleanup);
+    const before = readFileSync(join(f.dir, "draft_meta_info.json"), "utf-8");
+    const r = spawnCli(["register", f.dir, "--materials", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.applied, false);
+    assert.equal(r.json.needs_repair, true);
+    assert.deepEqual(r.json.repairs, ["draft_meta_info.json"]);
+    assert.equal(r.json.materials.action, "update");
+    assert.equal(r.json.materials.state, "unregistered");
+    assert.equal(r.json.materials.referenced, 1);
+    assert.equal(r.json.materials.registered, 0);
+    assert.deepEqual(r.json.materials.to_register, [join(f.dir, "assets", "video", "clip.mp4")]);
+    assert.match(r.stderr, /plan: update draft_meta_info.json draft_materials/);
+    assert.equal(readFileSync(join(f.dir, "draft_meta_info.json"), "utf-8"), before, "plan mode never writes");
+  });
+
+  it("--apply appends a PR-#14-shaped entry to the type-0 group, keeps the other groups, backs up the sidecar", () => {
+    const f = storeFixture();
+    after(f.cleanup);
+    const r = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.applied, ["draft_meta_info.json"]);
+    assert.deepEqual(r.json.backups, ["draft_meta_info.json.bak"]);
+    assert.ok(existsSync(join(f.dir, "draft_meta_info.json.bak")));
+    assert.match(r.stderr, /Registered 1 media file\(s\) in draft_materials/);
+
+    const meta = metaOnDisk(f.dir);
+    assert.equal(meta.draft_materials.length, 3, "non-zero groups are preserved");
+    const group0 = meta.draft_materials.find((g) => g.type === 0);
+    assert.equal(group0.value.length, 1);
+    const entry = group0.value[0];
+    assert.equal(entry.file_Path, join(f.dir, "assets", "video", "clip.mp4"));
+    assert.equal(entry.metetype, "video");
+    assert.equal(entry.extra_info, "clip.mp4");
+    assert.equal(entry.duration, 3_000_000);
+    assert.equal(entry.width, 1920);
+    assert.equal(entry.height, 1080);
+    assert.equal(entry.type, 0);
+    assert.equal(entry.item_source, 1);
+    assert.equal(entry.import_time, -1);
+    assert.equal(entry.md5, "");
+    assert.deepEqual(entry.roughcut_time_range, { duration: -1, start: -1 });
+    assert.match(entry.id, /^[0-9a-f-]{36}$/);
+    // The registration fields register already maintains are untouched.
+    assert.equal(meta.draft_id, "guid-materials-draft");
+    assert.equal(meta.draft_name, "materials-draft");
+    // The verify pass after the write reports the registration complete.
+    assert.equal(r.json.materials.state, "ok");
+    assert.equal(r.json.materials.registered, 1);
+  });
+
+  it("re-running is a no-op", () => {
+    const f = storeFixture();
+    after(f.cleanup);
+    assert.equal(spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]).status, 0);
+    const written = readFileSync(join(f.dir, "draft_meta_info.json"), "utf-8");
+    const again = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(again.status, 0, `stderr: ${again.stderr}`);
+    assert.deepEqual(again.json.applied, []);
+    assert.equal(again.json.materials.action, "none");
+    assert.match(again.json.message, /already registered/);
+    assert.equal(readFileSync(join(f.dir, "draft_meta_info.json"), "utf-8"), written);
+  });
+
+  it("photos get the nominal 5 s duration and audio registers as music with zero dimensions", () => {
+    const f = storeFixture({ photo: true, audio: true });
+    after(f.cleanup);
+    const r = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const group0 = metaOnDisk(f.dir).draft_materials.find((g) => g.type === 0);
+    assert.equal(group0.value.length, 3);
+    const still = group0.value.find((e) => e.file_Path.endsWith("still.png"));
+    assert.equal(still.metetype, "photo");
+    assert.equal(still.duration, 5_000_000);
+    assert.equal(still.width, 800);
+    const voice = group0.value.find((e) => e.file_Path.endsWith("voice.wav"));
+    assert.equal(voice.metetype, "music");
+    assert.equal(voice.duration, 2_500_000);
+    assert.equal(voice.width, 0);
+    assert.equal(voice.height, 0);
+    assert.equal(voice.extra_info, "voice.wav");
+  });
+
+  it("preserves existing entries and only appends what is missing", () => {
+    const f = storeFixture({ photo: true });
+    after(f.cleanup);
+    const existing = {
+      ai_group_type: "",
+      create_time: 1_700_000_000,
+      duration: 3_000_000,
+      enter_from: 0,
+      extra_info: "clip.mp4",
+      file_Path: join(f.dir, "assets", "video", "clip.mp4"),
+      height: 1080,
+      id: "APP-WRITTEN-ENTRY",
+      import_time: 1_700_000_000,
+      import_time_ms: 1_700_000_000_000,
+      item_source: 1,
+      material_color_tag: "",
+      md5: "abc",
+      metetype: "video",
+      roughcut_time_range: { duration: -1, start: -1 },
+      sub_time_range: { duration: -1, start: -1 },
+      type: 0,
+      width: 1920,
+    };
+    const stray = { ...existing, id: "STRAY", file_Path: "/somewhere/else.mp4", extra_info: "else.mp4" };
+    writeFileSync(
+      join(f.dir, "draft_meta_info.json"),
+      JSON.stringify(sidecar(f.root, f.dir, [{ type: 0, value: [existing, stray] }])),
+    );
+    const plan = spawnCli(["register", f.dir, "--materials", "--drafts", f.root]);
+    assert.equal(plan.status, 0, `stderr: ${plan.stderr}`);
+    assert.equal(plan.json.materials.registered, 1);
+    assert.deepEqual(plan.json.materials.to_register, [join(f.dir, "assets", "video", "still.png")]);
+    assert.equal(plan.json.materials.unreferenced_entries, 1, "the stray entry is counted, never removed");
+
+    const r = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const group0 = metaOnDisk(f.dir).draft_materials.find((g) => g.type === 0);
+    assert.equal(group0.value.length, 3);
+    assert.deepEqual(group0.value[0], existing, "the app-written entry is byte-for-byte preserved");
+    assert.deepEqual(group0.value[1], stray);
+    assert.equal(group0.value[2].metetype, "photo");
+  });
+
+  it("a missing sidecar is recreated and registered in ONE write", () => {
+    const f = storeFixture({ meta: null });
+    after(f.cleanup);
+    const r = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.deepEqual(r.json.applied, ["draft_meta_info.json"]);
+    assert.deepEqual(r.json.backups, [], "no .bak for a file that did not exist");
+    const meta = metaOnDisk(f.dir);
+    assert.equal(meta.draft_id, "guid-materials-draft", "the registration fields are written");
+    assert.equal(meta.draft_materials.find((g) => g.type === 0).value.length, 1, "and the media is registered");
+  });
+
+  it("creates the draft_materials array when the sidecar has no such key", () => {
+    const f = storeFixture({ meta: undefined });
+    after(f.cleanup);
+    const bare = metaOnDisk(f.dir);
+    delete bare.draft_materials;
+    writeFileSync(join(f.dir, "draft_meta_info.json"), JSON.stringify(bare));
+    const r = spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const meta = metaOnDisk(f.dir);
+    assert.deepEqual(
+      meta.draft_materials.map((g) => g.type),
+      [0],
+    );
+    assert.equal(meta.draft_materials[0].value.length, 1);
+  });
+
+  it("without --materials the sidecar's draft_materials is untouched and the plan has no materials key", () => {
+    const f = storeFixture();
+    after(f.cleanup);
+    const r = spawnCli(["register", f.dir, "--apply", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.materials, undefined);
+    assert.deepEqual(r.json.applied, []);
+    assert.deepEqual(metaOnDisk(f.dir).draft_materials, EMPTY_GROUPS);
+  });
+
+  it("reports no-media when the timeline references nothing local", () => {
+    const f = storeFixture({ withMedia: true });
+    after(f.cleanup);
+    const content = JSON.parse(readFileSync(join(f.dir, "draft_content.json"), "utf-8"));
+    content.materials.videos[0].path = "https://upload.wikimedia.org/x.webm";
+    writeFileSync(join(f.dir, "draft_content.json"), JSON.stringify(content));
+    const r = spawnCli(["register", f.dir, "--materials", "--drafts", f.root]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.materials.state, "no-media");
+    assert.equal(r.json.needs_repair, false);
+  });
+
+  it("clears lint's media-unregistered note", () => {
+    const f = storeFixture();
+    after(f.cleanup);
+    const before = spawnCli(["lint", join(f.dir, "draft_content.json"), "--no-probe"]);
+    assert.ok(
+      before.json.issues.some((i) => i.code === "media-unregistered"),
+      "precondition: the note fires",
+    );
+    assert.equal(spawnCli(["register", f.dir, "--materials", "--apply", "--drafts", f.root]).status, 0);
+    const afterFix = spawnCli(["lint", join(f.dir, "draft_content.json"), "--no-probe"]);
+    assert.equal(afterFix.status, 0, `stderr: ${afterFix.stderr}`);
+    assert.ok(!afterFix.json.issues.some((i) => i.code === "media-unregistered"));
+  });
+
+  it("describe lists --materials on register", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "register");
+    assert.ok(spec.options.some((o) => o.flags.includes("--materials")));
+  });
+});

--- a/test/render-soft-captions.test.mjs
+++ b/test/render-soft-captions.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { spawnCli } from "./helpers/spawn-cli.mjs";
+import { tmpDraft } from "./helpers/tmp-draft.mjs";
+
+// `render --soft-captions`: the text-track cues become an SRT beside the
+// output and a mov_text subtitle stream in the mp4. Asserted on the pure plan
+// (--dry-run) — no ffmpeg needed.
+
+function withVideoOnDisk(fix) {
+  // The fixture's video material must exist for the plan to have a main-track input.
+  const draft = JSON.parse(readFileSync(fix.path, "utf-8"));
+  for (const mat of draft.materials.videos) {
+    const p = join(fix.dir, `${mat.id}.mp4`);
+    writeFileSync(p, "stub");
+    mat.path = p;
+  }
+  writeFileSync(fix.path, JSON.stringify(draft));
+  return draft;
+}
+
+describe("render --soft-captions (dry-run plan)", () => {
+  it("adds the SRT input, maps it as a mov_text stream and drops -shortest", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    withVideoOnDisk(fix);
+    const out = join(fix.dir, "preview.mp4");
+    const r = spawnCli(["render", fix.path, "--dry-run", "--soft-captions", "--out", out]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const plan = r.json;
+    assert.ok(plan.softCaptions, "plan carries the soft captions block");
+    assert.equal(plan.softCaptions.path, join(fix.dir, "preview.srt"));
+    assert.ok(plan.softCaptions.cues > 0);
+    assert.match(plan.softCaptions.srt, /^1\r?\n\d\d:\d\d:\d\d,\d{3} --> /);
+    const subInput = plan.inputs.find((i) => i.kind === "subtitle");
+    assert.ok(subInput);
+    assert.equal(subInput.index, plan.softCaptions.inputIndex);
+    const { args } = plan;
+    assert.ok(args.includes(plan.softCaptions.path), "the SRT is an ffmpeg input");
+    assert.equal(args[args.indexOf(plan.softCaptions.path) - 1], "-i");
+    const mapIdx = args.indexOf(`${plan.softCaptions.inputIndex}:0`);
+    assert.ok(mapIdx > 0 && args[mapIdx - 1] === "-map", "the SRT stream is mapped");
+    assert.equal(args[args.indexOf("-c:s") + 1], "mov_text");
+    assert.equal(args[args.indexOf("-metadata:s:s:0") + 1], "language=und");
+    assert.ok(!args.includes("-shortest"), "-shortest would end the file at the last cue");
+    assert.equal(args[args.length - 1], out);
+    assert.ok(!existsSync(plan.softCaptions.path), "dry-run writes nothing");
+  });
+
+  it("without the flag the plan is unchanged: -shortest, no subtitle input, no softCaptions key", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    withVideoOnDisk(fix);
+    const r = spawnCli(["render", fix.path, "--dry-run", "--out", join(fix.dir, "preview.mp4")]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.equal(r.json.softCaptions, undefined);
+    assert.ok(r.json.args.includes("-shortest"));
+    assert.ok(!r.json.args.includes("mov_text"));
+    assert.ok(!r.json.inputs.some((i) => i.kind === "subtitle"));
+  });
+
+  it("combines with --burn-captions and notes a draft without text", (t) => {
+    const fix = tmpDraft();
+    t.after(() => fix.cleanup());
+    const draft = withVideoOnDisk(fix);
+    const both = spawnCli([
+      "render",
+      fix.path,
+      "--dry-run",
+      "--soft-captions",
+      "--burn-captions",
+      "--out",
+      join(fix.dir, "p.mp4"),
+    ]);
+    assert.equal(both.status, 0, `stderr: ${both.stderr}`);
+    assert.ok(both.json.textOverlays > 0);
+    assert.ok(both.json.softCaptions.cues > 0);
+
+    draft.tracks = draft.tracks.filter((t) => t.type !== "text");
+    writeFileSync(fix.path, JSON.stringify(draft));
+    const none = spawnCli(["render", fix.path, "--dry-run", "--soft-captions", "--out", join(fix.dir, "p.mp4")]);
+    assert.equal(none.status, 0, `stderr: ${none.stderr}`);
+    assert.equal(none.json.softCaptions, undefined);
+    assert.ok(none.json.skipped.some((s) => s.segmentId === "captions" && /no text segments/.test(s.reason)));
+    assert.ok(none.json.args.includes("-shortest"), "no subtitle stream → -shortest stays");
+  });
+
+  it("describe lists --soft-captions on render", () => {
+    const r = spawnCli(["describe"]);
+    const spec = r.json.commands.find((c) => c.name === "render");
+    assert.ok(spec.options.some((o) => o.flags.includes("--soft-captions")));
+  });
+});


### PR DESCRIPTION
v0.22.0 — nine items mined from what users are actually hitting, across this repo's issues, its forks, the downstream projects that build on it (vertir, qcut, OpenChatCut) and the wider CapCut/JianYing tooling ecosystem — each checked against what the CLI already did before it was built.

## New

- **`register --materials`** — writes the `draft_materials` registration CapCut 9.1 reads to decide what is imported; the fix for every clip showing as "file inaccessible" with a relink prompt ([pyCapCut#13](https://github.com/GuanYixuan/pyCapCut/issues/13), entry shape per [pyCapCut PR #14](https://github.com/GuanYixuan/pyCapCut/pull/14)). Folds into register's own sidecar write (one `.bak`); merges, never replaces; re-runs are no-ops.
- **`export-timeline --captions markers`** + caption import in **`import-timeline`** — caption cues travel as OTIO timeline markers on the Stack (OTIO has no title schema — [OpenTimelineIO#62](https://github.com/AcademySoftwareFoundation/OpenTimelineIO/issues/62), open since 2017); Resolve/Premiere show them as timeline markers and `import-timeline` rebuilds the text track from them. Default `skip` keeps today's documents byte-identical.
- **`caption --script <file>`** — whisper's word timing, your script's wording (names, terms, punctuation). Global alignment with a near-miss term; each script line is a cue boundary; the result reports matched / substituted / inserted words and warns below 50 % match.
- **`detect-retakes`** — finds the sentence the speaker fluffed and said again, from the draft's captions or an SRT, with the three guards (`--window`, `--min-words`, `--similarity`) that keep it from doing what the one ecosystem attempt did (collapse 29 minutes into 1:47). Later take kept; cuts + keeps in the detect-silence shape.
- **`render --soft-captions`** — a toggleable `mov_text` subtitle stream in the proxy plus `<preview>.srt` beside it; drops `-shortest` only when a subtitle stream is muxed.
- **Keyframe property aliases** — `scale`, `x`, `y`, `opacity` accepted by `keyframe`, `--batch` and compile, stored under the canonical names (the table vertir and qcut each re-implemented).
- **`keyframe --easing hold`** — the step easing CapCut cannot encode, emulated with a helper keyframe one frame before the next keyframe on that property.
- **`matting <project> <segment-id> [--off]`** — smart matting / "Remove background" / 智能抠像 on the segment's video material (flag 3, per pyJianYingDraft PRs [#183](https://github.com/GuanYixuan/pyJianYingDraft/pull/183)/[#184](https://github.com/GuanYixuan/pyJianYingDraft/pull/184); provenance in the schema docs).
- **`init` / `quickstart` `--ratio 9:16 | --width/--height`** — canvas at creation (the fork-proven ask); stamped into every timeline file the template ships.

## Changed

- `lint`'s `media-unregistered` note suggests `register <project> --materials --apply` instead of asking for a fixture first; `diagnose` says the same. Still info-severity, `fixable: false`.
- `export-timeline` names `--captions markers` in the text-track skip note.

No command was removed, no existing flag changed meaning, and existing JSON outputs keep their shape (new fields appear only when the new flag is used). 927 tests, 9 new test files. Full details in the [changelog](./CHANGELOG.md).

## Evidence note

Cross-repo intersection was thin this cycle: the repo is mature and most hot ecosystem pains are already shipped here. The list leans on Tier-1 evidence — the sidecar registration has a reproduced app failure behind it; the OTIO, script-alignment and retake items ride standing asks in neighbouring tools; the last four are ergonomics the downstream integrators and the most-diverged fork had built for themselves. Still gated, not built: `#44` mask keyframes (no on-disk encoding fixture yet) and the `#50` canonical-read flip.
